### PR TITLE
Feature: Align Bioportal and AgroPortal - part 4 - Independent scrolling and Concept tree autoscroll to selected node and UI bug fixes

### DIFF
--- a/app/assets/javascripts/bp_mappings.js.erb
+++ b/app/assets/javascripts/bp_mappings.js.erb
@@ -63,7 +63,6 @@ function loadMappings(value) {
                 }
             ]
         });
-        jQuery(".mappings.index a.facebox").facebox();
     });
 }
 
@@ -144,4 +143,3 @@ function deleteMappings() {
     }
   });
 }
-

--- a/app/assets/stylesheets/bioportal.scss
+++ b/app/assets/stylesheets/bioportal.scss
@@ -3,6 +3,10 @@
   background-color: var(--admin-color);
 }
 
+.tabs-container .tab-items > div button{
+  color: var(--primary-color) !important
+}
+
 a{
   text-decoration: none !important;
 }

--- a/app/assets/stylesheets/components/tabs_container.scss
+++ b/app/assets/stylesheets/components/tabs_container.scss
@@ -31,7 +31,7 @@
   transition: opacity 0.3s ease;
 
   a, button {
-    color: #5e5e5e !important;
+    color: #5e5e5e;
     border: none;
     background: none;
   }

--- a/app/assets/stylesheets/theme-variables.scss.erb
+++ b/app/assets/stylesheets/theme-variables.scss.erb
@@ -3,7 +3,7 @@
 <% themes = {
   "agroportal"  => { primary: "#3CB371", hover: "#41C67C", secondary: "#ffc107", light: "#F1F6FA" },
   "stageportal" => { primary: "#37AEA0", hover: "#3BBDAE", secondary: "#ffc107", light: "#ECF7F6" },
-  "bioportal"   => { primary: "#76A7CC", hover: "#6B96B7", secondary: "#ffc107", light: "#F0F5F6" },
+  "bioportal"   => { primary: "#234979", hover: "#6B96B7", secondary: "#ffc107", light: "#F0F5F6" },
   "ontoportal"  => { primary: "#5499a4", hover: "#6B96B7", secondary: "#ffc107", light: "#F1F6FA" },
   "testportal"  => { primary: "#5499a4", hover: "#6B96B7", secondary: "#ffc107", light: "#F1F6FA" }
 } %>

--- a/app/assets/stylesheets/tree.scss
+++ b/app/assets/stylesheets/tree.scss
@@ -1,6 +1,11 @@
 /********************
 ## TREE VIEW
 *********************/
+#tree_wrapper {
+  max-height: 70vh;
+  overflow-y: scroll;
+}
+
 div.tree_error {
   background: none repeat scroll 0 0 lightYellow;
   font-weight: 600;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -63,7 +63,7 @@ module ApplicationHelper
     node.children.sort! { |a, b| (a.prefLabel || a.id).downcase <=> (b.prefLabel || b.id).downcase }
     for child in node.children
       if child.id.eql?(id)
-        active_style = "class='active'"
+        active_style = "class='tree-link active'"
       else
         active_style = ""
       end

--- a/app/javascript/controllers/simple_tree_controller.js
+++ b/app/javascript/controllers/simple_tree_controller.js
@@ -1,60 +1,94 @@
 import {Controller} from "@hotwired/stimulus"
 import {useSimpleTree} from "../mixins/useSimpleTree";
 
+const TREE_VIEW_PAGES = ['classes', 'properties', 'schemes', 'collections', 'instances']
+
 export default class extends Controller {
-  connect() {
-    if (this.element.getAttribute('simple-tree-data-initial') == 0) {
-      return;
-    }
-    this.simpleTreeCollection = useSimpleTree(this.element,
-        this.#afterClick.bind(this),
-        this.#afterAjaxError.bind(this),
-        this.#beforeAjax.bind(this)
-    );
-    this.#onClickTooManyChildrenInit();
-    this.element.setAttribute('simple-tree-data-initial', 0);
-  }
 
-  #onClickTooManyChildrenInit(){
-    jQuery(".too_many_children_override").live('click', (event) =>  {
-      event.preventDefault();
-      let result = jQuery(event.target).closest("ul");
-      result.html("<img src='/images/tree/spinner.gif'>");
-      jQuery.ajax({
-        url: jQuery(event.target).attr('href'),
-        context: result,
-        success: function (data) {
-          this.html(data);
-          this.simpleTreeCollection.get(0).setTreeNodes(this);
-        },
-        error: function () {
-          this.html("<div style='background: #eeeeee; padding: 5px; width: 80%;'>Problem getting children. <a href='" + jQuery(this).attr('href') + "' class='too_many_children_override'>Try again</a></div>");
+
+
+    static values = {
+        autoClick: { type: Boolean, default: false }
+    }
+
+    connect() {
+        if (this.element.getAttribute('simple-tree-data-initial') == 0) {
+            return;
         }
-      });
-    });
-  }
+        this.simpleTreeCollection = useSimpleTree(this.element,
+            this.#afterClick.bind(this),
+            this.#afterAjaxError.bind(this),
+            this.#beforeAjax.bind(this)
+        );
 
-  #afterClick(node) {
-    const page_name = $(node.context).attr("data-bp-ont-page-name")
-    const conf = jQuery(document).data().bp.ont_viewer
-    const concept_id = jQuery(node).children("a").attr("id")
-    History.pushState({
-          p: "classes",
-          conceptid: concept_id
-        }, page_name + " | " + conf.org_site,
-        '?p=classes&conceptid=' + concept_id)
-  }
-
-  #afterAjaxError(node) {
-    this.simpleTreeCollection[0].option.animate = false;
-    this.simpleTreeCollection.get(0).nodeToggle(node.parent()[0]);
-    if (node.parent().children(".expansion_error").length === 0) {
-      node.parent().append("<span class='expansion_error'>Error, please try again");
+        this.#onClickTooManyChildrenInit();
+        this.element.setAttribute('simple-tree-data-initial', 0);
+        this.#centerTreeView()
     }
-    this.simpleTreeCollection[0].option.animate = true;
-  }
 
-  #beforeAjax(node) {
-    node.parent().children(".expansion_error").remove();
-  }
+    #centerTreeView() {
+        setTimeout(() => {
+            const location = window.location.href;
+
+            const isTreeViewPage = TREE_VIEW_PAGES.some(param => location.includes(`p=${param}`));
+
+            if (isTreeViewPage) {
+                const activeElem = this.element.querySelector('.tree-link.active');
+
+                if (activeElem) {
+                    activeElem.scrollIntoView({block: 'center'});
+                    window.scrollTo({top: 0});
+
+                    if (this.autoClickValue) {
+                        activeElem.click();
+                    }
+                }
+
+                this.#onClickTooManyChildrenInit();
+            }
+        }, 0);
+    }
+
+    #onClickTooManyChildrenInit() {
+        jQuery(".too_many_children_override").live('click', (event) => {
+            event.preventDefault();
+            let result = jQuery(event.target).closest("ul");
+            result.html("<img src='/images/tree/spinner.gif'>");
+            jQuery.ajax({
+                url: jQuery(event.target).attr('href'),
+                context: result,
+                success: function (data) {
+                    this.html(data);
+                    this.simpleTreeCollection.get(0).setTreeNodes(this);
+                },
+                error: function () {
+                    this.html("<div style='background: #eeeeee; padding: 5px; width: 80%;'>Problem getting children. <a href='" + jQuery(this).attr('href') + "' class='too_many_children_override'>Try again</a></div>");
+                }
+            });
+        });
+    }
+
+    #afterClick(node) {
+        const page_name = $(node.context).attr("data-bp-ont-page-name")
+        const conf = jQuery(document).data().bp.ont_viewer
+        const concept_id = jQuery(node).children("a").attr("id")
+        History.pushState({
+                p: "classes",
+                conceptid: concept_id
+            }, page_name + " | " + conf.org_site,
+            '?p=classes&conceptid=' + concept_id)
+    }
+
+    #afterAjaxError(node) {
+        this.simpleTreeCollection[0].option.animate = false;
+        this.simpleTreeCollection.get(0).nodeToggle(node.parent()[0]);
+        if (node.parent().children(".expansion_error").length === 0) {
+            node.parent().append("<span class='expansion_error'>Error, please try again");
+        }
+        this.simpleTreeCollection[0].option.animate = true;
+    }
+
+    #beforeAjax(node) {
+        node.parent().children(".expansion_error").remove();
+    }
 }

--- a/app/views/change_requests/_node_obsoletion.html.haml
+++ b/app/views/change_requests/_node_obsoletion.html.haml
@@ -1,4 +1,4 @@
-= form_with scope: :node_obsoletion, url: change_requests_path, data: {turbo: true}, class: 'mb-5' do |f|
+= form_with scope: :node_obsoletion, url: change_requests_path, data: {turbo: true, turbo_frame: '_top'}, class: 'mb-5' do |f|
   = hidden_field_tag 'concept_id', @concept_id
   = hidden_field_tag 'concept_label', @concept_label
   = hidden_field_tag 'github_id', @user.githubId

--- a/app/views/concepts/_details.html.haml
+++ b/app/views/concepts/_details.html.haml
@@ -14,11 +14,11 @@
           = link_to('Obsolete class',
                     change_requests_node_obsoletion_path(concept_id: @concept.id, concept_label: @concept.prefLabel,
                                                          ont_acronym: @ontology.acronym),
-                    class: 'dropdown-item', 'data-turbo': 'true', 'data-turbo-stream': 'true')
+                    class: 'dropdown-item', 'data-turbo': 'true', 'data-turbo-stream': 'true', 'data-turbo-frame': '_top')
           = link_to('Rename class',
                     change_requests_node_rename_path(concept_id: @concept.id, concept_label: @concept.prefLabel,
                                                      ont_acronym: @ontology.acronym),
-                    class: 'dropdown-item', 'data-turbo': 'true', 'data-turbo-stream': 'true')
+                    class: 'dropdown-item', 'data-turbo': 'true', 'data-turbo-stream': 'true','data-turbo-frame': '_top')
     %div{'data-controller': 'change-requests'}
       %div{id: 'addProposalFormDiv', 'data-change-requests-target': 'addProposalForm'}
 

--- a/app/views/concepts/_show.html.haml
+++ b/app/views/concepts/_show.html.haml
@@ -21,8 +21,10 @@
             Class Mappings (
             %span#mapping_count= @mappings.size
             )
-        - if $PURL_ENABLED
-          = link_to("#classPermalinkModal", class: "class-permalink nav-link", title: "Get a permanent link to this class", aria: {label: "Get a permanent link to this class"}, data: {toggle: "modal", current_purl: "#{@current_purl}"}) do
+        - if Rails.configuration.settings.purl[:enabled]
+          = link_to("#classPermalinkModal", class: "class-permalink py-1", title: "Get a link to this page",
+                      aria: {label: "Get a link to this page"},
+                      data: {"bs-toggle": "modal", current_purl: "#{@current_purl}"}) do
             %i{class: "fas fa-link", aria: {hidden: "true"}}
       #contents.tab-content
         #details_content.tab-pane.active.show

--- a/app/views/mappings/_count.html.haml
+++ b/app/views/mappings/_count.html.haml
@@ -14,7 +14,7 @@
           %td
             = link_to(mapping_count[:target_ontology][:name],
                       mapping_path(id: @ontology.acronym, target: mapping_count[:target_ontology][:id]),
-                      class: 'facebox')
+                      class: 'facebox', 'data-turbo': false)
           %td
             = number_with_delimiter(mapping_count[:count], delimiter: ',')
 

--- a/app/views/mappings/_mapping_table.html.haml
+++ b/app/views/mappings/_mapping_table.html.haml
@@ -29,9 +29,10 @@
     - ont_acronym = cls.links['ontology'].split("/").last
     - map_id = map.id.to_s.split("/").last
     %tr.human{id: map_id}
-      - if map.id && !map.id.empty? && session[:user] && (session[:user].id.to_i == map.creator || session[:user].admin?)
+      - if session[:user]
         %td.delete_mappings_column
-          = check_box_tag :delete_mapping_checkbox, map.id
+          - if map.id && !map.id.empty? && (session[:user].id.to_i == map.creator || session[:user].admin?)
+            = check_box_tag :delete_mapping_checkbox, map.id
       %td
         = link_to cls.id, ontology_path(id: ont_acronym, p: 'classes', conceptid: cls.id)
       %td

--- a/app/views/mappings/_mapping_table.html.haml
+++ b/app/views/mappings/_mapping_table.html.haml
@@ -14,7 +14,7 @@
 %table#concept_mappings_table.zebra
   %thead
     %tr
-      - if session[:user] && (session[:user].id.to_i == map.creator || session[:user].admin?)
+      - if session[:user]
         %th.delete_mappings_column Delete
       %th Mapping To
       %th Ontology

--- a/app/views/mappings/_mapping_table.html.haml
+++ b/app/views/mappings/_mapping_table.html.haml
@@ -1,11 +1,11 @@
 -# called from mappings_controller in several ways:
 -# 1. mappings_controller::get_concept_table via /app/views/mappings/_concept_mappings.html.haml
 -# 2. directly from mappings_controller::get_concept_table
--#NOTES on control over mapping deletion:
--#deleteMappings() is a callback that is called by "#delete_mappings_button" created below.
--#The appearance of that button is controlled by updateMappingDeletePermissions(), which
--#relies on @delete_mapping_permission in /app/views/mappings/_mapping_table.html.haml; which,
--#in turn, is set by /app/controllers/application_controller.check_delete_mapping_permission()
+-# NOTES on control over mapping deletion:
+-# deleteMappings() is a callback that is called by "#delete_mappings_button" created below.
+-# The appearance of that button is controlled by updateMappingDeletePermissions(), which
+-# relies on @delete_mapping_permission in /app/views/mappings/_mapping_table.html.haml; which,
+-# in turn, is set by /app/controllers/application_controller.check_delete_mapping_permission()
 -#
 -# The delete mappings button display is controlled by JS on page ready (see bp_mappings.js)
 -# check_box_tag(name, value = "1", checked = false, options = {})
@@ -14,7 +14,8 @@
 %table#concept_mappings_table.zebra
   %thead
     %tr
-      %th.delete_mappings_column Delete
+      - if session[:user] && (session[:user].id.to_i == map.creator || session[:user].admin?)
+        %th.delete_mappings_column Delete
       %th Mapping To
       %th Ontology
       %th Source
@@ -28,8 +29,8 @@
     - ont_acronym = cls.links['ontology'].split("/").last
     - map_id = map.id.to_s.split("/").last
     %tr.human{id: map_id}
-      %td.delete_mappings_column
-        - if map.id && !map.id.empty? && session[:user] && (session[:user].id.to_i == map.creator || session[:user].admin?)
+      - if map.id && !map.id.empty? && session[:user] && (session[:user].id.to_i == map.creator || session[:user].admin?)
+        %td.delete_mappings_column
           = check_box_tag :delete_mapping_checkbox, map.id
       %td
         = link_to cls.id, ontology_path(id: ont_acronym, p: 'classes', conceptid: cls.id)

--- a/app/views/ontologies/_treeview.html.haml
+++ b/app/views/ontologies/_treeview.html.haml
@@ -4,8 +4,3 @@
       %li.root
         %ul
           = draw_tree(@root, @concept.id)
-
-  :javascript
-    jQuery(document).ready(function () {
-      jQuery("#sd_content").scrollTo(jQuery('a.active'));
-    })

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,18 @@ en:
         A class that the authors of the ontology have flagged as being obsolete and which they recommend that people not use. These classes 
         are often left in ontologies (rather than removing them entirely) so that existing systems that depend on them will continue to function.
 
+  ontology_details:
+    sections:
+      classes: Classes
+      summary: Summary
+      properties: Properties
+      instances: Instances
+      notes: Notes
+      mappings: Mappings
+      widgets: Widgets
+      sparql: Sparql
+      concepts: Concepts
+
   projects:
     index:
       intro: Browse a selection of projects that use %{site} resources
@@ -88,4 +100,3 @@ en:
 
   mappings:
     intro: Browse mappings between classes in different ontologies
-


### PR DESCRIPTION
### Context
This PR adds the independent scrolling and tree auto-scroll features from the Radx project requirements and fixes all the issues raised in the precedent-merged PRs. 
In the next PR, we will implement the better concept details view.

### Changes 

- Fix: tree view container scroll (https://github.com/ontoportal/ontoportal_web_ui/commit/1c3e0718898200ce8e6142889b4c9a07a56c376e)

https://github.com/user-attachments/assets/537cba3b-bc8c-448f-a1bb-3aa907daef67


- Feature: add auto-scroll in the tree to go to the selected node (https://github.com/ontoportal/ontoportal_web_ui/commit/a412fb9e5853db92a66118e6f8df66f5fdc2383b)

https://github.com/user-attachments/assets/36fcd6c4-8918-4dc5-997c-0d370005f5bb
- Fix https://github.com/ncbo/bioportal_web_ui/issues/354 in https://github.com/ontoportal/ontoportal_web_ui/pull/27/commits/2c90e5adc8128a0a9e592abc5ca8a0ff7dfd024c
- Fix https://github.com/ncbo/bioportal_web_ui/issues/353 in https://github.com/ontoportal/ontoportal_web_ui/pull/27/commits/a3a27779845a476d4ab53b2b60292626b3c37398
- Fix https://github.com/ncbo/bioportal_web_ui/issues/355 in https://github.com/ontoportal/ontoportal_web_ui/pull/27/commits/2d25d2e3b155425193cbb77aa739ba14aff448a6
- Fix https://github.com/ncbo/bioportal_web_ui/issues/352 in https://github.com/ontoportal/ontoportal_web_ui/pull/27/commits/771c41f15beaf0a789affa99914a91a9e82cb79a
- Fix https://github.com/ncbo/bioportal_web_ui/issues/350 and https://github.com/ncbo/bioportal_web_ui/issues/351 in https://github.com/ontoportal/ontoportal_web_ui/pull/27/commits/c4c5258f272f239dcfdb8d2f7ff91300b19f5dd5
- FIx bioportal primary color 
![image](https://github.com/user-attachments/assets/fbb77820-c310-4bff-a2ee-877b7f675e51)

