### PR TITLE
Fix update_info behavior to preserve appliance_id on partial API errors

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -18,30 +18,36 @@ class AdminController < ApplicationController
     if session[:user].nil? || !session[:user].admin?
       redirect_to controller: 'login', action: 'index', redirect: '/admin'
     else
-      update_info(false)
+      update_info(render_response: false)
       render action: 'index'
     end
   end
 
-  def update_info(render_response = true)
+  def update_info(render_response: true)
     response = { update_info: {}, errors: '', success: '', notices: '' }
-    json = LinkedData::Client::HTTP.get("#{ADMIN_URL}update_info", params, raw: true)
 
     begin
+      json = LinkedData::Client::HTTP.get("#{ADMIN_URL}update_info", params, raw: true)
       update_info = JSON.parse(json)
 
+      # Always store @update_info, even if an error is present
+      @update_info = update_info.symbolize_keys
+
+      # Only treat it as a blocking error if no useful data exists
       if update_info['error']
+        # Log or surface the error, but don't block downstream access to valid fields
         response[:errors] = update_info['error']
-        response[:update_info] = update_info
       else
-        @update_info = update_info.symbolize_keys
-        response[:update_info] = update_info
-        response[:notices] = update_info['notes'] if update_info['notes']
         response[:success] = 'Update info successfully retrieved'
       end
+
+      response[:notices] = update_info['notes'] if update_info['notes']
+      response[:update_info] = update_info
     rescue StandardError => e
+      @update_info = {}
       response[:errors] = "Problem retrieving update info - #{e.message}"
     end
+
     render json: response if render_response
   end
 


### PR DESCRIPTION
- Refactored `update_info` method to always assign @update_info, even if the API response includes an "error" key.
- Ensured that partial failures (e.g., update check error) do not prevent access to valid fields like appliance_id.
- Updated method to use a keyword argument (`render_response: true`) instead of a positional boolean, improving readability and satisfying Rubocop guidelines.