### PR TITLE
Harden URI resolvability checks against SSRF

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,10 @@ gem 'countries', '~> 5.7'
 
 # Custom API client
 gem 'ontologies_api_client', git: 'https://github.com/agroportal/ontologies_api_ruby_client.git', branch: 'development'
+
+# SSRF protection for the URI resolvability checker
+gem 'ssrf_filter', '~> 1.5'
+
 # Ruby 2.7.8 pinned gems (to remove when migrating to Ruby >= 3.0)
 
 gem 'ffi', '~> 1.16.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -601,6 +601,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
+    ssrf_filter (1.5.0)
     stackprof (0.2.27)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
@@ -733,6 +734,7 @@ DEPENDENCIES
   simplecov-cobertura
   sparql (~> 3.3)
   sprockets-rails
+  ssrf_filter (~> 1.5)
   stackprof (~> 0.2.27)
   stimulus-rails
   string-similarity

--- a/app/helpers/check_resolvability_helper.rb
+++ b/app/helpers/check_resolvability_helper.rb
@@ -1,4 +1,51 @@
+require 'benchmark'
+require 'ipaddr'
+require 'net/http'
+require 'resolv'
+require 'timeout'
+require 'uri'
+
 module CheckResolvabilityHelper
+
+  RESOLVABILITY_ALLOWED_SCHEMES = %w[http https].freeze
+  RESOLVABILITY_ALLOWED_PORT_RANGE = 1..65_535
+  RESOLVABILITY_BLOCKED_HOSTNAMES = %w[localhost localhost.localdomain].freeze
+  RESOLVABILITY_BLOCKED_IP_RANGES = %w[
+    0.0.0.0/8
+    10.0.0.0/8
+    100.64.0.0/10
+    127.0.0.0/8
+    169.254.0.0/16
+    172.16.0.0/12
+    192.0.0.0/24
+    192.0.2.0/24
+    192.88.99.0/24
+    192.168.0.0/16
+    198.18.0.0/15
+    198.51.100.0/24
+    203.0.113.0/24
+    224.0.0.0/4
+    240.0.0.0/4
+    255.255.255.255/32
+    ::/128
+    ::1/128
+    ::/96
+    ::ffff:0:0/96
+    64:ff9b::/96
+    64:ff9b:1::/48
+    100::/64
+    100:0:0:1::/64
+    2001::/23
+    2001:2::/48
+    2001:db8::/32
+    2002::/16
+    3fff::/20
+    5f00::/16
+    fc00::/7
+    fe80::/10
+    fec0::/10
+    ff00::/8
+  ].map { |range| IPAddr.new(range) }.freeze
 
   def formats_equivalents(format = nil)
     all = {
@@ -42,26 +89,119 @@ module CheckResolvabilityHelper
     { result: result, status: status, allowed_format: supported_format, response_time: response_time, redirections: redirections }
   end
 
+  def check_resolvability_error(key)
+    I18n.t("check_resolvability.errors.#{key}")
+  end
+
+  def public_resolvability_uri(url)
+    raw_url = url.to_s.strip
+    raise ArgumentError, check_resolvability_error(:url_required) if raw_url.empty?
+
+    uri = URI.parse(raw_url)
+    unless uri.is_a?(URI::HTTP) && RESOLVABILITY_ALLOWED_SCHEMES.include?(uri.scheme)
+      raise ArgumentError, check_resolvability_error(:http_only)
+    end
+
+    raise ArgumentError, check_resolvability_error(:host_required) if uri.hostname.to_s.empty?
+    raise ArgumentError, check_resolvability_error(:credentials_forbidden) if uri.userinfo
+    raise ArgumentError, check_resolvability_error(:invalid_port) unless RESOLVABILITY_ALLOWED_PORT_RANGE.cover?(uri.port)
+
+    uri
+  rescue URI::Error
+    raise ArgumentError, check_resolvability_error(:invalid_url)
+  end
+
+  def public_resolvability_hostname(uri)
+    uri.hostname.to_s.downcase.delete_suffix('.')
+  end
+
+  def public_resolvability_connection_ip(uri, timeout_seconds = resolvability_timeout)
+    host = public_resolvability_hostname(uri)
+    raise ArgumentError, check_resolvability_error(:host_required) if host.empty?
+
+    if RESOLVABILITY_BLOCKED_HOSTNAMES.include?(host) || host.end_with?('.localhost')
+      raise ArgumentError, check_resolvability_error(:non_public_host)
+    end
+
+    ip_literal = parse_resolvability_ip(host)
+    addresses = ip_literal ? [ip_literal.to_s] : public_resolvability_dns_addresses(host, timeout_seconds)
+
+    if addresses.empty? || addresses.any? { |address| !public_resolvability_ip_address?(address) }
+      raise ArgumentError, check_resolvability_error(:non_public_address)
+    end
+
+    addresses.first.to_s
+  end
+
+  def public_resolvability_dns_addresses(host, timeout_seconds = resolvability_timeout)
+    if host !~ /[.:]/
+      raise ArgumentError, check_resolvability_error(:single_label_host)
+    end
+
+    Timeout.timeout(timeout_seconds) { Array(Resolv.getaddresses(host)) }
+  rescue Resolv::ResolvError, Timeout::Error
+    []
+  end
+
+  def public_resolvability_ip_address?(address)
+    ip = address.is_a?(IPAddr) ? address : IPAddr.new(address)
+    RESOLVABILITY_BLOCKED_IP_RANGES.none? { |range| range.include?(ip) }
+  rescue IPAddr::Error
+    false
+  end
+
+  def parse_resolvability_ip(address)
+    IPAddr.new(address)
+  rescue IPAddr::Error
+    nil
+  end
+
+  def public_resolvability_redirect_uri(uri, location)
+    location = location.to_s.strip
+    raise ArgumentError, check_resolvability_error(:invalid_redirect) if location.empty?
+
+    joined_uri = begin
+      URI.join(uri, location)
+    rescue URI::Error
+      raise ArgumentError, check_resolvability_error(:invalid_redirect)
+    end
+
+    public_resolvability_uri(joined_uri.to_s)
+  end
+
+  def resolvability_request_uri(uri)
+    request_uri = uri.request_uri
+    request_uri.nil? || request_uri.empty? ? '/' : request_uri
+  end
+
   def follow_redirection(url, format, timeout_seconds, redirect_limit = resolvability_max_redirections)
-    url = url.strip
-    uri = URI.parse(url)
+    uri = public_resolvability_uri(url)
     response = nil
     redirect_count = 0
     redirections = [uri]
 
     total_time = Benchmark.measure do
       until (!response.nil? && !response.is_a?(Net::HTTPRedirection)) || redirect_count >= redirect_limit
-        http = Net::HTTP.new(uri.host, uri.port)
+        connection_ip = public_resolvability_connection_ip(uri, timeout_seconds)
+        http = Net::HTTP.new(public_resolvability_hostname(uri), uri.port, nil)
+        unless http.respond_to?(:ipaddr=)
+          raise ArgumentError, check_resolvability_error(:ip_pinning_unavailable)
+        end
+        http.ipaddr = connection_ip
         http.use_ssl = (uri.scheme == 'https')
         http.open_timeout = timeout_seconds
+        http.read_timeout = timeout_seconds if http.respond_to?(:read_timeout=)
         begin
-          response = Timeout.timeout(timeout_seconds) { http.request_head(uri, 'Accept' => format) }
+          response = Timeout.timeout(timeout_seconds) { http.request_head(resolvability_request_uri(uri), 'Accept' => format) }
         rescue Timeout::Error, Net::OpenTimeout
           return resolvability_status('Timeout', [], redirections, result: 0, response_time: timeout_seconds)
         end
 
-        if response.is_a?(Net::HTTPRedirection) && response['location']
-          uri = URI.join(uri, response['location'])
+        if response.is_a?(Net::HTTPRedirection)
+          break if response['location'].to_s.strip.empty?
+
+          uri = public_resolvability_redirect_uri(uri, response['location'])
+          public_resolvability_connection_ip(uri, timeout_seconds)
           redirections << uri
           redirect_count += 1
         end

--- a/app/helpers/check_resolvability_helper.rb
+++ b/app/helpers/check_resolvability_helper.rb
@@ -1,51 +1,13 @@
 require 'benchmark'
-require 'ipaddr'
 require 'net/http'
-require 'resolv'
+require 'ssrf_filter'
 require 'timeout'
 require 'uri'
 
 module CheckResolvabilityHelper
 
-  RESOLVABILITY_ALLOWED_SCHEMES = %w[http https].freeze
   RESOLVABILITY_ALLOWED_PORT_RANGE = 1..65_535
   RESOLVABILITY_BLOCKED_HOSTNAMES = %w[localhost localhost.localdomain].freeze
-  RESOLVABILITY_BLOCKED_IP_RANGES = %w[
-    0.0.0.0/8
-    10.0.0.0/8
-    100.64.0.0/10
-    127.0.0.0/8
-    169.254.0.0/16
-    172.16.0.0/12
-    192.0.0.0/24
-    192.0.2.0/24
-    192.88.99.0/24
-    192.168.0.0/16
-    198.18.0.0/15
-    198.51.100.0/24
-    203.0.113.0/24
-    224.0.0.0/4
-    240.0.0.0/4
-    255.255.255.255/32
-    ::/128
-    ::1/128
-    ::/96
-    ::ffff:0:0/96
-    64:ff9b::/96
-    64:ff9b:1::/48
-    100::/64
-    100:0:0:1::/64
-    2001::/23
-    2001:2::/48
-    2001:db8::/32
-    2002::/16
-    3fff::/20
-    5f00::/16
-    fc00::/7
-    fe80::/10
-    fec0::/10
-    ff00::/8
-  ].map { |range| IPAddr.new(range) }.freeze
 
   def formats_equivalents(format = nil)
     all = {
@@ -89,89 +51,78 @@ module CheckResolvabilityHelper
     { result: result, status: status, allowed_format: supported_format, response_time: response_time, redirections: redirections }
   end
 
-  def check_resolvability_error(key)
-    I18n.t("check_resolvability.errors.#{key}")
-  end
-
-  def public_resolvability_uri(url)
-    raw_url = url.to_s.strip
-    raise ArgumentError, check_resolvability_error(:url_required) if raw_url.empty?
-
-    uri = URI.parse(raw_url)
-    unless uri.is_a?(URI::HTTP) && RESOLVABILITY_ALLOWED_SCHEMES.include?(uri.scheme)
-      raise ArgumentError, check_resolvability_error(:http_only)
-    end
-
-    raise ArgumentError, check_resolvability_error(:host_required) if uri.hostname.to_s.empty?
-    raise ArgumentError, check_resolvability_error(:credentials_forbidden) if uri.userinfo
-    raise ArgumentError, check_resolvability_error(:invalid_port) unless RESOLVABILITY_ALLOWED_PORT_RANGE.cover?(uri.port)
-
-    uri
-  rescue URI::Error
-    raise ArgumentError, check_resolvability_error(:invalid_url)
+  # Every rejection reports the same opaque message. Saying which check refused a URL
+  # would let a caller read back internal DNS and network layout one request at a time.
+  def check_resolvability_blocked
+    I18n.t('check_resolvability.blocked')
   end
 
   def public_resolvability_hostname(uri)
     uri.hostname.to_s.downcase.delete_suffix('.')
   end
 
-  def public_resolvability_connection_ip(uri, timeout_seconds = resolvability_timeout)
+  def public_resolvability_uri?(uri)
+    return false unless uri.is_a?(URI::HTTP) && SsrfFilter::DEFAULT_SCHEME_WHITELIST.include?(uri.scheme)
+    return false if uri.userinfo
+    return false unless RESOLVABILITY_ALLOWED_PORT_RANGE.cover?(uri.port)
+
     host = public_resolvability_hostname(uri)
-    raise ArgumentError, check_resolvability_error(:host_required) if host.empty?
+    return false if host.empty?
+    return false if RESOLVABILITY_BLOCKED_HOSTNAMES.include?(host) || host.end_with?('.localhost')
 
-    if RESOLVABILITY_BLOCKED_HOSTNAMES.include?(host) || host.end_with?('.localhost')
-      raise ArgumentError, check_resolvability_error(:non_public_host)
-    end
-
-    ip_literal = parse_resolvability_ip(host)
-    addresses = ip_literal ? [ip_literal.to_s] : public_resolvability_dns_addresses(host, timeout_seconds)
-
-    if addresses.empty? || addresses.any? { |address| !public_resolvability_ip_address?(address) }
-      raise ArgumentError, check_resolvability_error(:non_public_address)
-    end
-
-    addresses.first.to_s
+    # A bare label can resolve through the resolver's search domains onto an intranet host.
+    host.match?(/[.:]/)
   end
 
-  def public_resolvability_dns_addresses(host, timeout_seconds = resolvability_timeout)
-    if host !~ /[.:]/
-      raise ArgumentError, check_resolvability_error(:single_label_host)
-    end
+  def public_resolvability_uri(url)
+    raw_url = url.to_s.strip
+    raise ArgumentError, check_resolvability_blocked if raw_url.empty?
 
-    Timeout.timeout(timeout_seconds) { Array(Resolv.getaddresses(host)) }
-  rescue Resolv::ResolvError, Timeout::Error
-    []
-  end
+    uri = URI.parse(raw_url)
+    raise ArgumentError, check_resolvability_blocked unless public_resolvability_uri?(uri)
 
-  def public_resolvability_ip_address?(address)
-    ip = address.is_a?(IPAddr) ? address : IPAddr.new(address)
-    RESOLVABILITY_BLOCKED_IP_RANGES.none? { |range| range.include?(ip) }
-  rescue IPAddr::Error
-    false
-  end
-
-  def parse_resolvability_ip(address)
-    IPAddr.new(address)
-  rescue IPAddr::Error
-    nil
+    uri
+  rescue URI::Error
+    raise ArgumentError, check_resolvability_blocked
   end
 
   def public_resolvability_redirect_uri(uri, location)
     location = location.to_s.strip
-    raise ArgumentError, check_resolvability_error(:invalid_redirect) if location.empty?
+    raise ArgumentError, check_resolvability_blocked if location.empty?
 
     joined_uri = begin
       URI.join(uri, location)
     rescue URI::Error
-      raise ArgumentError, check_resolvability_error(:invalid_redirect)
+      raise ArgumentError, check_resolvability_blocked
     end
 
     public_resolvability_uri(joined_uri.to_s)
   end
 
-  def resolvability_request_uri(uri)
-    request_uri = uri.request_uri
-    request_uri.nil? || request_uri.empty? ? '/' : request_uri
+  def resolvability_ssrf_options(format, timeout_seconds)
+    {
+      headers: { 'Accept' => format },
+      # Redirects are followed here rather than by SsrfFilter so that every hop can be
+      # reported, and so that relative locations resolve through URI.join.
+      max_redirects: 0,
+      allow_unfollowed_redirects: true,
+      http_options: {
+        open_timeout: timeout_seconds,
+        read_timeout: timeout_seconds,
+        # Net::HTTP.start proxies from the environment unless told otherwise, which would
+        # connect to the proxy instead of the address SsrfFilter validated and pinned.
+        proxy_from_env: false
+      }
+    }
+  end
+
+  def resolvability_head(uri, format, timeout_seconds)
+    # Guards the DNS lookup, which no Net::HTTP timeout covers.
+    Timeout.timeout(timeout_seconds) do
+      SsrfFilter.head(uri.to_s, resolvability_ssrf_options(format, timeout_seconds))
+    end
+  rescue SsrfFilter::Error
+    raise ArgumentError, check_resolvability_blocked
   end
 
   def follow_redirection(url, format, timeout_seconds, redirect_limit = resolvability_max_redirections)
@@ -182,18 +133,9 @@ module CheckResolvabilityHelper
 
     total_time = Benchmark.measure do
       until (!response.nil? && !response.is_a?(Net::HTTPRedirection)) || redirect_count >= redirect_limit
-        connection_ip = public_resolvability_connection_ip(uri, timeout_seconds)
-        http = Net::HTTP.new(public_resolvability_hostname(uri), uri.port, nil)
-        unless http.respond_to?(:ipaddr=)
-          raise ArgumentError, check_resolvability_error(:ip_pinning_unavailable)
-        end
-        http.ipaddr = connection_ip
-        http.use_ssl = (uri.scheme == 'https')
-        http.open_timeout = timeout_seconds
-        http.read_timeout = timeout_seconds if http.respond_to?(:read_timeout=)
         begin
-          response = Timeout.timeout(timeout_seconds) { http.request_head(resolvability_request_uri(uri), 'Accept' => format) }
-        rescue Timeout::Error, Net::OpenTimeout
+          response = resolvability_head(uri, format, timeout_seconds)
+        rescue Timeout::Error
           return resolvability_status('Timeout', [], redirections, result: 0, response_time: timeout_seconds)
         end
 
@@ -201,7 +143,6 @@ module CheckResolvabilityHelper
           break if response['location'].to_s.strip.empty?
 
           uri = public_resolvability_redirect_uri(uri, response['location'])
-          public_resolvability_connection_ip(uri, timeout_seconds)
           redirections << uri
           redirect_count += 1
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,6 +357,18 @@ en:
     submit: Submit
     type: Type
   check_resolvability:
+    errors:
+      url_required: 'Blocked unsafe URL: URL is required'
+      invalid_url: 'Blocked unsafe URL: invalid URL'
+      http_only: 'Blocked unsafe URL: only HTTP and HTTPS URLs are allowed'
+      host_required: 'Blocked unsafe URL: host is required'
+      credentials_forbidden: 'Blocked unsafe URL: credentials are not allowed'
+      single_label_host: 'Blocked unsafe URL: single-label hosts are not allowed'
+      non_public_host: 'Blocked unsafe URL: host is not public'
+      non_public_address: 'Blocked unsafe URL: host does not resolve to a public address'
+      invalid_port: 'Blocked unsafe URL: invalid port'
+      ip_pinning_unavailable: 'Blocked unsafe URL: HTTP client does not support IP pinning'
+      invalid_redirect: 'Blocked unsafe URL: invalid redirect'
     check_resolvability_message_1: 'The URL is resolvable and support the following
       formats: %{supported_format}'
     check_resolvability_message_2: 'The URL is resolvable but is not content negotiable,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,18 +357,7 @@ en:
     submit: Submit
     type: Type
   check_resolvability:
-    errors:
-      url_required: 'Blocked unsafe URL: URL is required'
-      invalid_url: 'Blocked unsafe URL: invalid URL'
-      http_only: 'Blocked unsafe URL: only HTTP and HTTPS URLs are allowed'
-      host_required: 'Blocked unsafe URL: host is required'
-      credentials_forbidden: 'Blocked unsafe URL: credentials are not allowed'
-      single_label_host: 'Blocked unsafe URL: single-label hosts are not allowed'
-      non_public_host: 'Blocked unsafe URL: host is not public'
-      non_public_address: 'Blocked unsafe URL: host does not resolve to a public address'
-      invalid_port: 'Blocked unsafe URL: invalid port'
-      ip_pinning_unavailable: 'Blocked unsafe URL: HTTP client does not support IP pinning'
-      invalid_redirect: 'Blocked unsafe URL: invalid redirect'
+    blocked: Blocked URL
     check_resolvability_message_1: 'The URL is resolvable and support the following
       formats: %{supported_format}'
     check_resolvability_message_2: 'The URL is resolvable but is not content negotiable,

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -365,6 +365,18 @@ fr:
     submit: Soumettre
     type: Type
   check_resolvability:
+    errors:
+      url_required: "URL non fournie"
+      invalid_url: "URL invalide"
+      http_only: "Seules les URL HTTP et HTTPS sont autorisées"
+      host_required: "L'hôte est requis"
+      credentials_forbidden: "Les identifiants ne sont pas autorisés"
+      single_label_host: "Les hôtes à étiquette unique ne sont pas autorisés"
+      non_public_host: "L'hôte n'est pas public"
+      non_public_address: "L'hôte ne résout pas vers une adresse publique"
+      invalid_port: "Port invalide"
+      ip_pinning_unavailable: "Le client HTTP ne prend pas en charge l'association à une adresse IP"
+      invalid_redirect: "Redirection invalide"
     check_resolvability_message_1: 'L''URL est résolvable et supporte les formats
       suivants : %{supported_format}'
     check_resolvability_message_2: 'L''URL est résolvable mais sont contenu n''est

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -365,18 +365,7 @@ fr:
     submit: Soumettre
     type: Type
   check_resolvability:
-    errors:
-      url_required: "URL non fournie"
-      invalid_url: "URL invalide"
-      http_only: "Seules les URL HTTP et HTTPS sont autorisées"
-      host_required: "L'hôte est requis"
-      credentials_forbidden: "Les identifiants ne sont pas autorisés"
-      single_label_host: "Les hôtes à étiquette unique ne sont pas autorisés"
-      non_public_host: "L'hôte n'est pas public"
-      non_public_address: "L'hôte ne résout pas vers une adresse publique"
-      invalid_port: "Port invalide"
-      ip_pinning_unavailable: "Le client HTTP ne prend pas en charge l'association à une adresse IP"
-      invalid_redirect: "Redirection invalide"
+    blocked: URL bloquée
     check_resolvability_message_1: 'L''URL est résolvable et supporte les formats
       suivants : %{supported_format}'
     check_resolvability_message_2: 'L''URL est résolvable mais sont contenu n''est

--- a/test/helpers/check_resolvability_helper_test.rb
+++ b/test/helpers/check_resolvability_helper_test.rb
@@ -1,0 +1,285 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/mock'
+
+class CheckResolvabilityHelperTest < ActionView::TestCase
+  include CheckResolvabilityHelper
+
+  test 'rejects unsafe URLs before making a request' do
+    constructor_called = false
+
+    Net::HTTP.stub(:new, lambda { |*|
+      constructor_called = true
+      raise 'HTTP client must not be constructed'
+    }) do
+      result = check_resolvability_helper('http://127.0.0.1/admin', ['text/html'], 1)
+
+      assert_equal 0, result[:result]
+      assert_equal translated_error(:non_public_address), result[:status]
+    end
+
+    assert_not constructor_called
+  end
+
+  test 'rejects invalid and special-purpose URLs' do
+    cases = {
+      nil => :url_required,
+      'file:///etc/passwd' => :http_only,
+      'http:///resource' => :host_required,
+      'http://user:pass@example.com/' => :credentials_forbidden,
+      'http://example/' => :single_label_host,
+      'http://localhost/' => :non_public_host,
+      'http://example.com:0/' => :invalid_port,
+      'http://example.com:65536/' => :invalid_port,
+      'http://[broken/' => :invalid_url,
+      'http://[::1]/' => :non_public_address,
+      'http://[64:ff9b:1::7f00:1]/' => :non_public_address,
+      'http://[100:0:0:1::1]/' => :non_public_address,
+      'http://[3fff::1]/' => :non_public_address,
+      'http://[5f00::1]/' => :non_public_address,
+      'http://[fec0::1]/' => :non_public_address
+    }
+
+    cases.each do |url, key|
+      result = check_resolvability_helper(url, ['text/html'], 1)
+
+      assert_equal 0, result[:result], url.inspect
+      assert_equal translated_error(key), result[:status], url.inspect
+    end
+  end
+
+  test 'rejects hostnames with any private resolved address' do
+    stub_public_dns('metadata.example' => ['93.184.216.34', '10.0.0.5']) do
+      result = check_resolvability_helper('http://metadata.example/latest', ['text/html'], 1)
+
+      assert_equal 0, result[:result]
+      assert_equal translated_error(:non_public_address), result[:status]
+    end
+  end
+
+  test 'rejects invalid resolved addresses' do
+    stub_public_dns('invalid.example' => ['not-an-ip']) do
+      result = check_resolvability_helper('http://invalid.example/', ['text/html'], 1)
+
+      assert_equal 0, result[:result]
+      assert_equal translated_error(:non_public_address), result[:status]
+    end
+  end
+
+  test 'revalidates redirects before following them' do
+    response = redirect_response('http://169.254.169.254/latest/meta-data')
+    fake_http = FakeHeadClient.new(response)
+    http_new_calls = 0
+
+    stub_public_dns('public.example' => ['93.184.216.34']) do
+      Net::HTTP.stub(:new, lambda { |*args|
+        http_new_calls += 1
+        assert_equal ['public.example', 80, nil], args
+        fake_http
+      }) do
+        result = check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
+
+        assert_equal 0, result[:result]
+        assert_equal translated_error(:non_public_address), result[:status]
+      end
+    end
+
+    assert_equal 1, http_new_calls
+    assert_equal [['/resource', { 'Accept' => 'text/html' }]], fake_http.requests
+  end
+
+  test 'follows a safe redirect to a successful response' do
+    redirect = redirect_response('https://safe.example/final')
+    success = Net::HTTPOK.new('1.1', '200', 'OK')
+    success['Content-Type'] = 'text/html'
+    fake_http = FakeHeadClient.new(redirect, success)
+    constructor_args = []
+
+    stub_public_dns(
+      'public.example' => ['93.184.216.34'],
+      'safe.example' => ['93.184.216.35']
+    ) do
+      Net::HTTP.stub(:new, lambda { |*args|
+        constructor_args << args
+        fake_http
+      }) do
+        result = check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
+
+        assert_equal 1, result[:result]
+      end
+    end
+
+    assert_equal [
+      ['public.example', 80, nil],
+      ['safe.example', 443, nil]
+    ], constructor_args
+    assert_equal [
+      ['/resource', { 'Accept' => 'text/html' }],
+      ['/final', { 'Accept' => 'text/html' }]
+    ], fake_http.requests
+    assert_equal ['93.184.216.34', '93.184.216.35'], fake_http.ipaddrs
+  end
+
+  test 'terminates a redirect without a location' do
+    fake_http = FakeHeadClient.new(Net::HTTPFound.new('1.1', '302', 'Found'))
+
+    stub_public_dns('public.example' => ['93.184.216.34']) do
+      Net::HTTP.stub(:new, ->(*) { fake_http }) do
+        result = check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
+
+        assert_equal 0, result[:result]
+        assert_equal '302', result[:status]
+      end
+    end
+
+    assert_equal 1, fake_http.requests.size
+  end
+
+  test 'reports malformed redirect locations safely' do
+    response = redirect_response('http://[broken')
+    fake_http = FakeHeadClient.new(response)
+
+    stub_public_dns('public.example' => ['93.184.216.34']) do
+      Net::HTTP.stub(:new, ->(*) { fake_http }) do
+        result = check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
+
+        assert_equal 0, result[:result]
+        assert_equal translated_error(:invalid_redirect), result[:status]
+      end
+    end
+  end
+
+  test 'disables environment proxies and pins the validated IP' do
+    success = Net::HTTPOK.new('1.1', '200', 'OK')
+    fake_http = FakeHeadClient.new(success)
+    constructor_args = []
+    previous_proxy = ENV['http_proxy']
+    ENV['http_proxy'] = 'http://127.0.0.1:8888'
+
+    stub_public_dns('public.example' => ['93.184.216.34']) do
+      Net::HTTP.stub(:new, lambda { |*args|
+        constructor_args << args
+        fake_http
+      }) do
+        result = check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
+
+        assert_equal 1, result[:result]
+      end
+    end
+
+    assert_equal [['public.example', 80, nil]], constructor_args
+    assert_equal ['93.184.216.34'], fake_http.ipaddrs
+  ensure
+    if previous_proxy.nil?
+      ENV.delete('http_proxy')
+    else
+      ENV['http_proxy'] = previous_proxy
+    end
+  end
+
+  test 'allows a public hostname on a valid non-default port' do
+    success = Net::HTTPOK.new('1.1', '200', 'OK')
+    fake_http = FakeHeadClient.new(success)
+    constructor_args = []
+
+    stub_public_dns('public.example' => ['93.184.216.34']) do
+      Net::HTTP.stub(:new, lambda { |*args|
+        constructor_args << args
+        fake_http
+      }) do
+        result = check_resolvability_helper('http://public.example:8080/resource', ['text/html'], 1)
+
+        assert_equal 1, result[:result]
+      end
+    end
+
+    assert_equal [['public.example', 8080, nil]], constructor_args
+    assert_equal ['93.184.216.34'], fake_http.ipaddrs
+  end
+
+  test 'uses the unbracketed hostname for public IPv6 literals' do
+    success = Net::HTTPOK.new('1.1', '200', 'OK')
+    fake_http = FakeHeadClient.new(success)
+    constructor_args = []
+
+    Net::HTTP.stub(:new, lambda { |*args|
+      constructor_args << args
+      fake_http
+    }) do
+      result = check_resolvability_helper('http://[2001:4860:4860::8888]/resource', ['text/html'], 1)
+
+      assert_equal 1, result[:result]
+    end
+
+    assert_equal [['2001:4860:4860::8888', 80, nil]], constructor_args
+    assert_equal ['2001:4860:4860::8888'], fake_http.ipaddrs
+  end
+
+  test 'localizes rejection statuses in French' do
+    I18n.with_locale(:fr) do
+      result = check_resolvability_helper('http://127.0.0.1/', ['text/html'], 1)
+
+      assert_equal I18n.t('check_resolvability.errors.non_public_address'), result[:status]
+      refute_equal I18n.t('check_resolvability.errors.non_public_address', locale: :en), result[:status]
+    end
+  end
+
+  test 'reports missing IP pinning support' do
+    success = Net::HTTPOK.new('1.1', '200', 'OK')
+
+    stub_public_dns('public.example' => ['93.184.216.34']) do
+      Net::HTTP.stub(:new, ->(*) { NoPinningClient.new(success) }) do
+        result = check_resolvability_helper('http://public.example/', ['text/html'], 1)
+
+        assert_equal 0, result[:result]
+        assert_equal translated_error(:ip_pinning_unavailable), result[:status]
+      end
+    end
+  end
+
+  private
+
+  class FakeHeadClient
+    attr_accessor :ipaddr, :open_timeout, :read_timeout, :use_ssl
+    attr_reader :requests, :ipaddrs
+
+    def initialize(*responses)
+      @responses = responses
+      @requests = []
+      @ipaddrs = []
+    end
+
+    def ipaddr=(address)
+      @ipaddrs << address
+      @ipaddr = address
+    end
+
+    def request_head(path, headers)
+      @requests << [path, headers]
+      @responses.shift || @responses.last
+    end
+  end
+
+  class NoPinningClient
+    def initialize(response)
+      @response = response
+    end
+
+    def request_head(*); @response; end
+  end
+
+  def redirect_response(location)
+    response = Net::HTTPFound.new('1.1', '302', 'Found')
+    response['Location'] = location
+    response
+  end
+
+  def stub_public_dns(mapping)
+    Resolv.stub(:getaddresses, ->(host) { mapping.fetch(host) { [] } }) { yield }
+  end
+
+  def translated_error(key)
+    I18n.t("check_resolvability.errors.#{key}")
+  end
+end

--- a/test/helpers/check_resolvability_helper_test.rb
+++ b/test/helpers/check_resolvability_helper_test.rb
@@ -6,267 +6,233 @@ require 'minitest/mock'
 class CheckResolvabilityHelperTest < ActionView::TestCase
   include CheckResolvabilityHelper
 
-  test 'rejects unsafe URLs before making a request' do
-    constructor_called = false
-
-    Net::HTTP.stub(:new, lambda { |*|
-      constructor_called = true
-      raise 'HTTP client must not be constructed'
-    }) do
+  test 'rejects unsafe URLs before opening a connection' do
+    refute_connects do
       result = check_resolvability_helper('http://127.0.0.1/admin', ['text/html'], 1)
 
       assert_equal 0, result[:result]
-      assert_equal translated_error(:non_public_address), result[:status]
+      assert_equal blocked_message, result[:status]
     end
-
-    assert_not constructor_called
   end
 
   test 'rejects invalid and special-purpose URLs' do
-    cases = {
-      nil => :url_required,
-      'file:///etc/passwd' => :http_only,
-      'http:///resource' => :host_required,
-      'http://user:pass@example.com/' => :credentials_forbidden,
-      'http://example/' => :single_label_host,
-      'http://localhost/' => :non_public_host,
-      'http://example.com:0/' => :invalid_port,
-      'http://example.com:65536/' => :invalid_port,
-      'http://[broken/' => :invalid_url,
-      'http://[::1]/' => :non_public_address,
-      'http://[64:ff9b:1::7f00:1]/' => :non_public_address,
-      'http://[100:0:0:1::1]/' => :non_public_address,
-      'http://[3fff::1]/' => :non_public_address,
-      'http://[5f00::1]/' => :non_public_address,
-      'http://[fec0::1]/' => :non_public_address
-    }
+    urls = [
+      nil,
+      'file:///etc/passwd',
+      'http:///resource',
+      'http://user:pass@example.com/',
+      'http://example/',
+      'http://localhost/',
+      'http://example.com:0/',
+      'http://example.com:65536/',
+      'http://[broken/',
+      'http://[::1]/',
+      # IPv4 private ranges re-encoded as IPv6 (mapped, compatible, and NAT64 forms)
+      'http://[::ffff:127.0.0.1]/',
+      'http://[::ffff:169.254.169.254]/',
+      'http://[::7f00:1]/',
+      'http://[64:ff9b::7f00:1]/',
+      'http://[64:ff9b:1::7f00:1]/'
+    ]
 
-    cases.each do |url, key|
-      result = check_resolvability_helper(url, ['text/html'], 1)
+    refute_connects do
+      urls.each do |url|
+        result = check_resolvability_helper(url, ['text/html'], 1)
 
-      assert_equal 0, result[:result], url.inspect
-      assert_equal translated_error(key), result[:status], url.inspect
+        assert_equal 0, result[:result], url.inspect
+        assert_equal blocked_message, result[:status], url.inspect
+      end
     end
   end
 
-  test 'rejects hostnames with any private resolved address' do
-    stub_public_dns('metadata.example' => ['93.184.216.34', '10.0.0.5']) do
-      result = check_resolvability_helper('http://metadata.example/latest', ['text/html'], 1)
+  # A caller able to tell these apart could map internal DNS and network layout.
+  test 'does not reveal why a URL was rejected' do
+    refute_connects do
+      statuses = stub_dns('private.example' => ['10.0.0.5']) do
+        [
+          check_resolvability_helper('http://private.example/', ['text/html'], 1)[:status],
+          check_resolvability_helper('http://nowhere.example/', ['text/html'], 1)[:status],
+          check_resolvability_helper('http://[broken/', ['text/html'], 1)[:status]
+        ]
+      end
 
-      assert_equal 0, result[:result]
-      assert_equal translated_error(:non_public_address), result[:status]
+      assert_equal [blocked_message] * 3, statuses
     end
   end
 
-  test 'rejects invalid resolved addresses' do
-    stub_public_dns('invalid.example' => ['not-an-ip']) do
-      result = check_resolvability_helper('http://invalid.example/', ['text/html'], 1)
+  test 'connects to a public address when a hostname also resolves to a private one' do
+    stub_dns('mixed.example' => ['93.184.216.34', '10.0.0.5']) do
+      stub_http(ok_response) do |_connection, starts|
+        result = check_resolvability_helper('http://mixed.example/', ['text/html'], 1)
 
-      assert_equal 0, result[:result]
-      assert_equal translated_error(:non_public_address), result[:status]
+        assert_equal 1, result[:result]
+        assert_equal ['93.184.216.34'], pinned_addresses(starts)
+      end
     end
   end
 
-  test 'revalidates redirects before following them' do
-    response = redirect_response('http://169.254.169.254/latest/meta-data')
-    fake_http = FakeHeadClient.new(response)
-    http_new_calls = 0
+  test 'disables the environment proxy and pins the validated address' do
+    stub_dns('public.example' => ['93.184.216.34']) do
+      stub_http(ok_response) do |_connection, starts|
+        check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
 
-    stub_public_dns('public.example' => ['93.184.216.34']) do
-      Net::HTTP.stub(:new, lambda { |*args|
-        http_new_calls += 1
-        assert_equal ['public.example', 80, nil], args
-        fake_http
-      }) do
+        _host, _port, options = starts.first
+        assert_equal '93.184.216.34', options[:ipaddr]
+        assert_equal false, options[:proxy_from_env]
+        assert_equal 1, options[:open_timeout]
+        assert_equal 1, options[:read_timeout]
+      end
+    end
+  end
+
+  test 'revalidates each redirect hop before following it' do
+    stub_dns('public.example' => ['93.184.216.34']) do
+      stub_http(redirect_response('http://169.254.169.254/latest/meta-data')) do |connection, starts|
         result = check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
 
         assert_equal 0, result[:result]
-        assert_equal translated_error(:non_public_address), result[:status]
+        assert_equal blocked_message, result[:status]
+        assert_equal 1, connection.requests.size
+        assert_equal ['93.184.216.34'], pinned_addresses(starts)
       end
     end
-
-    assert_equal 1, http_new_calls
-    assert_equal [['/resource', { 'Accept' => 'text/html' }]], fake_http.requests
   end
 
   test 'follows a safe redirect to a successful response' do
-    redirect = redirect_response('https://safe.example/final')
-    success = Net::HTTPOK.new('1.1', '200', 'OK')
-    success['Content-Type'] = 'text/html'
-    fake_http = FakeHeadClient.new(redirect, success)
-    constructor_args = []
-
-    stub_public_dns(
-      'public.example' => ['93.184.216.34'],
-      'safe.example' => ['93.184.216.35']
-    ) do
-      Net::HTTP.stub(:new, lambda { |*args|
-        constructor_args << args
-        fake_http
-      }) do
+    stub_dns('public.example' => ['93.184.216.34'], 'safe.example' => ['93.184.216.35']) do
+      stub_http(redirect_response('https://safe.example/final'), ok_response('text/html')) do |connection, starts|
         result = check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
 
         assert_equal 1, result[:result]
+        assert_equal [['public.example', 80], ['safe.example', 443]], starts.map { |host, port, _| [host, port] }
+        assert_equal [false, true], starts.map { |_host, _port, options| options[:use_ssl] }
+        assert_equal ['93.184.216.34', '93.184.216.35'], pinned_addresses(starts)
+        assert_equal [['/resource', 'text/html'], ['/final', 'text/html']], requested(connection)
       end
     end
+  end
 
-    assert_equal [
-      ['public.example', 80, nil],
-      ['safe.example', 443, nil]
-    ], constructor_args
-    assert_equal [
-      ['/resource', { 'Accept' => 'text/html' }],
-      ['/final', { 'Accept' => 'text/html' }]
-    ], fake_http.requests
-    assert_equal ['93.184.216.34', '93.184.216.35'], fake_http.ipaddrs
+  test 'follows a relative redirect location' do
+    stub_dns('public.example' => ['93.184.216.34']) do
+      stub_http(redirect_response('other.html'), ok_response('text/html')) do |connection, _starts|
+        result = check_resolvability_helper('http://public.example/docs/resource', ['text/html'], 1)
+
+        assert_equal 1, result[:result]
+        assert_equal ['/docs/resource', '/docs/other.html'], connection.requests.map(&:path)
+      end
+    end
   end
 
   test 'terminates a redirect without a location' do
-    fake_http = FakeHeadClient.new(Net::HTTPFound.new('1.1', '302', 'Found'))
-
-    stub_public_dns('public.example' => ['93.184.216.34']) do
-      Net::HTTP.stub(:new, ->(*) { fake_http }) do
+    stub_dns('public.example' => ['93.184.216.34']) do
+      stub_http(Net::HTTPFound.new('1.1', '302', 'Found')) do |connection, _starts|
         result = check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
 
         assert_equal 0, result[:result]
         assert_equal '302', result[:status]
+        assert_equal 1, connection.requests.size
       end
     end
-
-    assert_equal 1, fake_http.requests.size
   end
 
   test 'reports malformed redirect locations safely' do
-    response = redirect_response('http://[broken')
-    fake_http = FakeHeadClient.new(response)
-
-    stub_public_dns('public.example' => ['93.184.216.34']) do
-      Net::HTTP.stub(:new, ->(*) { fake_http }) do
+    stub_dns('public.example' => ['93.184.216.34']) do
+      stub_http(redirect_response('http://[broken')) do |_connection, _starts|
         result = check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
 
         assert_equal 0, result[:result]
-        assert_equal translated_error(:invalid_redirect), result[:status]
+        assert_equal blocked_message, result[:status]
       end
-    end
-  end
-
-  test 'disables environment proxies and pins the validated IP' do
-    success = Net::HTTPOK.new('1.1', '200', 'OK')
-    fake_http = FakeHeadClient.new(success)
-    constructor_args = []
-    previous_proxy = ENV['http_proxy']
-    ENV['http_proxy'] = 'http://127.0.0.1:8888'
-
-    stub_public_dns('public.example' => ['93.184.216.34']) do
-      Net::HTTP.stub(:new, lambda { |*args|
-        constructor_args << args
-        fake_http
-      }) do
-        result = check_resolvability_helper('http://public.example/resource', ['text/html'], 1)
-
-        assert_equal 1, result[:result]
-      end
-    end
-
-    assert_equal [['public.example', 80, nil]], constructor_args
-    assert_equal ['93.184.216.34'], fake_http.ipaddrs
-  ensure
-    if previous_proxy.nil?
-      ENV.delete('http_proxy')
-    else
-      ENV['http_proxy'] = previous_proxy
     end
   end
 
   test 'allows a public hostname on a valid non-default port' do
-    success = Net::HTTPOK.new('1.1', '200', 'OK')
-    fake_http = FakeHeadClient.new(success)
-    constructor_args = []
-
-    stub_public_dns('public.example' => ['93.184.216.34']) do
-      Net::HTTP.stub(:new, lambda { |*args|
-        constructor_args << args
-        fake_http
-      }) do
+    stub_dns('public.example' => ['93.184.216.34']) do
+      stub_http(ok_response) do |_connection, starts|
         result = check_resolvability_helper('http://public.example:8080/resource', ['text/html'], 1)
 
         assert_equal 1, result[:result]
+        assert_equal [['public.example', 8080]], starts.map { |host, port, _| [host, port] }
+        assert_equal ['93.184.216.34'], pinned_addresses(starts)
       end
     end
-
-    assert_equal [['public.example', 8080, nil]], constructor_args
-    assert_equal ['93.184.216.34'], fake_http.ipaddrs
   end
 
   test 'uses the unbracketed hostname for public IPv6 literals' do
-    success = Net::HTTPOK.new('1.1', '200', 'OK')
-    fake_http = FakeHeadClient.new(success)
-    constructor_args = []
-
-    Net::HTTP.stub(:new, lambda { |*args|
-      constructor_args << args
-      fake_http
-    }) do
+    stub_http(ok_response) do |_connection, starts|
       result = check_resolvability_helper('http://[2001:4860:4860::8888]/resource', ['text/html'], 1)
 
       assert_equal 1, result[:result]
+      assert_equal [['2001:4860:4860::8888', 80]], starts.map { |host, port, _| [host, port] }
+      assert_equal ['2001:4860:4860::8888'], pinned_addresses(starts)
     end
-
-    assert_equal [['2001:4860:4860::8888', 80, nil]], constructor_args
-    assert_equal ['2001:4860:4860::8888'], fake_http.ipaddrs
   end
 
   test 'localizes rejection statuses in French' do
     I18n.with_locale(:fr) do
       result = check_resolvability_helper('http://127.0.0.1/', ['text/html'], 1)
 
-      assert_equal I18n.t('check_resolvability.errors.non_public_address'), result[:status]
-      refute_equal I18n.t('check_resolvability.errors.non_public_address', locale: :en), result[:status]
-    end
-  end
-
-  test 'reports missing IP pinning support' do
-    success = Net::HTTPOK.new('1.1', '200', 'OK')
-
-    stub_public_dns('public.example' => ['93.184.216.34']) do
-      Net::HTTP.stub(:new, ->(*) { NoPinningClient.new(success) }) do
-        result = check_resolvability_helper('http://public.example/', ['text/html'], 1)
-
-        assert_equal 0, result[:result]
-        assert_equal translated_error(:ip_pinning_unavailable), result[:status]
-      end
+      assert_equal 'URL bloquée', result[:status]
+      refute_equal I18n.t('check_resolvability.blocked', locale: :en), result[:status]
     end
   end
 
   private
 
-  class FakeHeadClient
-    attr_accessor :ipaddr, :open_timeout, :read_timeout, :use_ssl
-    attr_reader :requests, :ipaddrs
+  # Stands in for the Net::HTTP instance SsrfFilter yields itself from Net::HTTP.start.
+  class FakeConnection
+    attr_reader :requests
 
-    def initialize(*responses)
+    def initialize(responses)
       @responses = responses
       @requests = []
-      @ipaddrs = []
     end
 
-    def ipaddr=(address)
-      @ipaddrs << address
-      @ipaddr = address
-    end
-
-    def request_head(path, headers)
-      @requests << [path, headers]
+    def request(request)
+      @requests << request
       @responses.shift || @responses.last
     end
   end
 
-  class NoPinningClient
-    def initialize(response)
-      @response = response
-    end
+  # SsrfFilter connects via Net::HTTP.start, passing the address it validated as :ipaddr.
+  def stub_http(*responses)
+    connection = FakeConnection.new(responses)
+    starts = []
 
-    def request_head(*); @response; end
+    Net::HTTP.stub(:start, lambda { |host, port, **options, &block|
+      starts << [host, port, options]
+      block.call(connection)
+    }) do
+      yield connection, starts
+    end
+  end
+
+  def refute_connects
+    Net::HTTP.stub(:start, ->(*) { flunk('a connection must not be opened') }) do
+      yield
+    end
+  end
+
+  # SsrfFilter's default resolver reads addresses through Resolv.getaddresses, which
+  # answers IP literals from the address itself rather than consulting a resolver.
+  def stub_dns(mapping)
+    Resolv.stub(:getaddresses, lambda { |host|
+      Resolv::AddressRegex.match?(host) ? [host] : mapping.fetch(host) { [] }
+    }) { yield }
+  end
+
+  def pinned_addresses(starts)
+    starts.map { |_host, _port, options| options[:ipaddr] }
+  end
+
+  def requested(connection)
+    connection.requests.map { |request| [request.path, request['accept']] }
+  end
+
+  def ok_response(content_type = nil)
+    response = Net::HTTPOK.new('1.1', '200', 'OK')
+    response['Content-Type'] = content_type if content_type
+    response
   end
 
   def redirect_response(location)
@@ -275,11 +241,7 @@ class CheckResolvabilityHelperTest < ActionView::TestCase
     response
   end
 
-  def stub_public_dns(mapping)
-    Resolv.stub(:getaddresses, ->(host) { mapping.fetch(host) { [] } }) { yield }
-  end
-
-  def translated_error(key)
-    I18n.t("check_resolvability.errors.#{key}")
+  def blocked_message
+    I18n.t('check_resolvability.blocked')
   end
 end


### PR DESCRIPTION
The URI checker sends outbound HEAD requests for ontology links. It currently follows user-supplied destinations without restricting them to public network addresses, which can expose internal services.

This change accepts only credential-free HTTP(S) URLs, rejects non-public DNS and IP targets, disables environment proxies, and pins each request to the validated address. Redirect targets go through the same checks before they are followed. Public non-default ports remain supported, and rejection messages are available in English and French.

The focused helper test passes with 13 runs and 64 assertions. It uses stubbed DNS and HTTP clients; no external requests are made.
