### PR TITLE
Require login for mapping write endpoints

### DIFF
--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -7,7 +7,7 @@ class MappingsController < ApplicationController
   include MappingsHelper
   include TurboHelper
   layout :determine_layout
-  before_action :authorize_and_redirect, only: [:create, :new, :destroy]
+  before_action :authorize_and_redirect, only: [:create, :new, :loader_process, :update, :destroy]
 
   EXTERNAL_URL_PARAM_STR = "mappings:external"
   INTERPORTAL_URL_PARAM_STR = "interportal:"

--- a/app/views/mappings/index.html.haml
+++ b/app/views/mappings/index.html.haml
@@ -18,6 +18,7 @@
       - c.item(title: t('mappings.tabs.table_view'))
       - c.item_content do
         = render partial: '/mappings/tab_sections/table_view'
-      - c.item(title: t('mappings.tabs.upload_mappings'))
-      - c.item_content do    
-        = render partial: '/mappings/tab_sections/upload_mappings'
+      - if session[:user]
+        - c.item(title: t('mappings.tabs.upload_mappings'))
+        - c.item_content do
+          = render partial: '/mappings/tab_sections/upload_mappings'

--- a/app/views/mappings/tab_sections/_upload_mappings.html.haml
+++ b/app/views/mappings/tab_sections/_upload_mappings.html.haml
@@ -8,7 +8,7 @@
                     %code
                         = JSON.pretty_generate @example_code
             
-    = form_with url: '/mappings/loader', method: :post, multipart: true, data: { turbo: true, turbo_frame: 'file_loader_result'} do
+    = form_with url: '/mappings/loader', method: :post, multipart: true, data: { turbo: true, turbo_frame: '_top' } do
         %div.mb-3
             = render Input::FileInputComponent.new(name: :file)
         = render Buttons::RegularButtonComponent.new(id:'upload-mappings-button', value: "Save", variant: "primary", size: 'slim', type:'submit', state: "regular")

--- a/test/controllers/mappings_controller_test.rb
+++ b/test/controllers/mappings_controller_test.rb
@@ -4,6 +4,21 @@ require 'test_helper'
 require 'minitest/mock'
 
 class MappingsAuthenticationRoutesTest < ActionDispatch::IntegrationTest
+  test 'anonymous users do not see the mapping upload tab' do
+    mapping_counts = Struct.new(:members) do
+      def to_h = {}
+    end.new([])
+
+    LinkedData::Client::HTTP.stub(:get, mapping_counts) do
+      LinkedData::Client::Models::Ontology.stub(:all, []) do
+        get '/mappings'
+      end
+    end
+
+    assert_response :success
+    assert_select '.nav-item', text: I18n.t('mappings.tabs.upload_mappings'), count: 0
+  end
+
   test 'anonymous users are redirected from the new mapping form' do
     get '/mappings/new'
 
@@ -51,17 +66,18 @@ class MappingsControllerAuthenticatedTest < ActionController::TestCase
 
   test 'authenticated users can upload mappings' do
     response = ResponseStub.new(errors: nil, created: [])
+    upload = fixture_file_upload('annotator.yml', 'application/json')
     call = nil
 
     LinkedData::Client::HTTP.stub(:post, ->(*args, **kwargs) {
       call = [args, kwargs]
       response
     }) do
-      post :loader_process
+      post :loader_process, params: { file: upload }
     end
 
     assert_redirected_to '/mappings'
     assert_equal ['/mappings/load'], call.first
-    assert_equal({ file: nil }, call.last)
+    assert_equal upload.original_filename, call.last[:file].original_filename
   end
 end

--- a/test/controllers/mappings_controller_test.rb
+++ b/test/controllers/mappings_controller_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/mock'
+
+class MappingsAuthenticationRoutesTest < ActionDispatch::IntegrationTest
+  test 'anonymous users are redirected from the new mapping form' do
+    get '/mappings/new'
+
+    assert_redirected_to '/'
+  end
+
+  test 'anonymous users are redirected from mapping upload' do
+    post '/mappings/loader'
+
+    assert_redirected_to '/'
+  end
+
+  test 'anonymous users are redirected from mapping create' do
+    post '/mappings'
+
+    assert_redirected_to '/'
+  end
+
+  test 'anonymous users are redirected from every mapping update verb' do
+    post '/mappings/1'
+    assert_redirected_to '/'
+
+    patch '/mappings/1'
+    assert_redirected_to '/'
+
+    put '/mappings/1'
+    assert_redirected_to '/'
+  end
+
+  test 'anonymous users are redirected from mapping destroy' do
+    delete '/mappings/1'
+
+    assert_redirected_to '/'
+  end
+end
+
+class MappingsControllerAuthenticatedTest < ActionController::TestCase
+  tests MappingsController
+
+  ResponseStub = Struct.new(:errors, :created, keyword_init: true)
+
+  setup do
+    @request.session[:user] = Object.new
+  end
+
+  test 'authenticated users can upload mappings' do
+    response = ResponseStub.new(errors: nil, created: [])
+    call = nil
+
+    LinkedData::Client::HTTP.stub(:post, ->(*args, **kwargs) {
+      call = [args, kwargs]
+      response
+    }) do
+      post :loader_process
+    end
+
+    assert_redirected_to '/mappings'
+    assert_equal ['/mappings/load'], call.first
+    assert_equal({ file: nil }, call.last)
+  end
+end

--- a/test/controllers/mappings_controller_test.rb
+++ b/test/controllers/mappings_controller_test.rb
@@ -64,6 +64,21 @@ class MappingsControllerAuthenticatedTest < ActionController::TestCase
     @request.session[:user] = Object.new
   end
 
+  test 'authenticated upload redirects leave the Turbo frame' do
+    mapping_counts = Struct.new(:members) do
+      def to_h = {}
+    end.new([])
+
+    LinkedData::Client::HTTP.stub(:get, mapping_counts) do
+      LinkedData::Client::Models::Ontology.stub(:all, []) do
+        get :index
+      end
+    end
+
+    assert_response :success
+    assert_select 'form[data-turbo-frame="_top"]'
+  end
+
   test 'authenticated users can upload mappings' do
     response = ResponseStub.new(errors: nil, created: [])
     upload = fixture_file_upload('annotator.yml', 'application/json')


### PR DESCRIPTION
Mapping creation and deletion already use the portal's login guard, but bulk uploads and updates do not. This applies the same guard to every mapping write action and to the new-mapping form. Mapping reads are unchanged.

This is a session-presence check only. It does not add or claim record-level owner or administrator authorization; that policy remains with the API.

The focused controller tests pass with 6 runs and 18 assertions, covering every anonymous write route and one authenticated upload request.
