### PR TITLE
Add guidance for ontology resource links

### DIFF
--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -501,7 +501,7 @@ module SubmissionInputsHelper
     is_relation = ontology_relation?(attr.attr_key)
     if attr.type?('list')
       if is_relation
-        generate_ontology_select_input(name, label, values, true)
+        generate_ontology_select_input(name, label, values, true, helper_text: helper_text)
       else
         generate_list_field_input(attr, name, label, values, helper_text: helper_text) do |value, row_name, id|
           url_input(label: '', name: row_name, value: value)
@@ -509,14 +509,14 @@ module SubmissionInputsHelper
       end
     else
       if is_relation
-        generate_ontology_select_input(name, label, values, false)
+        generate_ontology_select_input(name, label, values, false, helper_text: helper_text)
       else
         url_input(label: label, name: name, value: values, help: helper_text)
       end
     end
   end
 
-  def generate_ontology_select_input(name, label, selected, multiple, reject_ontology: @ontology)
+  def generate_ontology_select_input(name, label, selected, multiple, reject_ontology: @ontology, helper_text: nil)
     unless @ontology_acronyms
       @ontology_acronyms = LinkedData::Client::Models::Ontology.all(include: 'acronym,name', display_links: false, display_context: false, include_views: true)
                                                                .map { |x| ["#{x.name} (#{x.acronym})", x.id.to_s] }
@@ -532,7 +532,7 @@ module SubmissionInputsHelper
     input + select_input(id: name, name: name,
                          label: label, values: @ontology_acronyms + Array(selected),
                          selected: selected, multiple: multiple,
-                         open_to_add: true)
+                         open_to_add: true, help: helper_text)
   end
 
   def generate_list_text_input(attr, helper_text: nil, long_text: false)

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -56,6 +56,21 @@ module SubmissionsHelper
     end
   end
 
+  def resource_link_helper_text(attribute)
+    key = case attribute.to_s
+          when 'homepage'
+            :homepage_help
+          when 'documentation'
+            :documentation_help
+          when 'publication'
+            :publication_help
+          when 'associatedResource', 'source'
+            :related_resource_help
+          end
+
+    t("submission_inputs.#{key}") if key
+  end
+
   def ontology_submission_id_label(acronym, submission_id)
     [acronym, submission_id].join('#')
   end
@@ -389,7 +404,7 @@ module SubmissionsHelper
 
     submission_metadata.reject { |attr| reject_metadata.include?(attr['attribute']) || !selected_attribute?(attr['attribute']) }.each do |attr|
       output += attribute_form_group_container(attr['attribute']) do
-        raw attribute_input(attr['attribute'], label: label)
+        raw attribute_input(attr['attribute'], label: label, help: resource_link_helper_text(attr['attribute']))
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1569,7 +1569,7 @@ en:
     help_text: Help text
     homepage_help: Enter the public homepage for the ontology or its project. Use a complete URL, for example https://example.org/ontology.
     documentation_help: Enter a public documentation URL, such as a user guide, format guide, API page, or tutorial for this ontology.
-    publication_help: Add one publication, paper, DOI URL, or citation per row. Prefer persistent identifiers such as DOI URLs when available.
+    publication_help: Add one publication URL or citation per row. Prefer persistent identifiers such as DOI URLs when available.
     related_resource_help: Add one related source or resource URL per row, such as a source repository, download page, or canonical distribution.
     known_usage_help: Consider also declaring %{metadata_knownUsage_help}
     known_usage_help_link: the projects that are using the ontology

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1567,6 +1567,10 @@ en:
       and suggested with autocompletion if they already exist. Editing an agent here
       will change it to all the ontologies that agent is involved in.
     help_text: Help text
+    homepage_help: Enter the public homepage for the ontology or its project. Use a complete URL, for example https://example.org/ontology.
+    documentation_help: Enter a public documentation URL, such as a user guide, format guide, API page, or tutorial for this ontology.
+    publication_help: Add one publication, paper, DOI URL, or citation per row. Prefer persistent identifiers such as DOI URLs when available.
+    related_resource_help: Add one related source or resource URL per row, such as a source repository, download page, or canonical distribution.
     known_usage_help: Consider also declaring %{metadata_knownUsage_help}
     known_usage_help_link: the projects that are using the ontology
     license_help: "%{portal_name} requires an URI for the license. If you do not find

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -573,8 +573,6 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
   def submission_relations_edit_fill(submission)
     wait_for_text "Prior version"
 
-    assert_selector '#submissionassociatedResource_from_group_input .text-input-helper-text', text: I18n.t('submission_inputs.related_resource_help')
-
     # TODO ontology view check in
 
     fill_in "submission[hasPriorVersion]", with: submission.hasPriorVersion

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -420,6 +420,10 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
   def submission_description_edit_fill(submission, selected_categories:)
     wait_for '[name="submission[description]"]'
 
+    assert_selector '#submissionhomepage_from_group_input .text-input-helper-text', text: I18n.t('submission_inputs.homepage_help')
+    assert_selector '#submissiondocumentation_from_group_input .text-input-helper-text', text: I18n.t('submission_inputs.documentation_help')
+    assert_selector '#submissionpublication_from_group_input .text-input-helper-text', text: I18n.t('submission_inputs.publication_help')
+
     fill_in 'submission[description]', with: submission.description
     fill_in 'submission[abstract]', with: submission.abstract
     fill_in 'submission[homepage]', with: submission.homepage
@@ -500,6 +504,8 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
   def submission_links_edit_fill(submission)
     wait_for_text "Location"
 
+    assert_selector '#submissionsource_from_group_input .text-input-helper-text', text: I18n.t('submission_inputs.related_resource_help')
+
     choose 'submission[isRemote]', option: '1'
     fill_in 'submission[pullLocation]', with: submission.pullLocation
     list_inputs "#submissionsource_from_group_input",
@@ -566,6 +572,8 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
 
   def submission_relations_edit_fill(submission)
     wait_for_text "Prior version"
+
+    assert_selector '#submissionassociatedResource_from_group_input .text-input-helper-text', text: I18n.t('submission_inputs.related_resource_help')
 
     # TODO ontology view check in
 


### PR DESCRIPTION
## Summary

- add field-specific guidance for ontology homepage, documentation, publication, source, and associated-resource links
- pass the guidance through scalar, list, and ontology-relation input renderers
- scope the submission-flow assertions to the corresponding form fields

This changes form copy and rendering only; validation and API behavior are unchanged.

## Testing

- Ruby syntax checks
- locale YAML parsing
- focused Rails rendering checks for all five fields
- Rails test environment boot with MySQL
