### PR TITLE
Add optional Matomo analytics consent

### DIFF
--- a/app/assets/javascripts/cookie_consent.js
+++ b/app/assets/javascripts/cookie_consent.js
@@ -1,0 +1,50 @@
+(function () {
+  function clearMatomoCookies() {
+    var expires = 'expires=Thu, 01 Jan 1970 00:00:00 GMT';
+
+    document.cookie.split(';').forEach(function (entry) {
+      var name = entry.split('=')[0].trim();
+      if (/^(?:_pk_|mtm_)/i.test(name)) {
+        document.cookie = name + '=; ' + expires + '; path=/';
+      }
+    });
+  }
+
+  function revokeMatomoConsent() {
+    window._paq = window._paq || [];
+    window._paq.push(['forgetCookieConsentGiven']);
+    window._paq.push(['deleteCookies']);
+    clearMatomoCookies();
+  }
+
+  function initCookieConsentBanners() {
+    document.querySelectorAll('[data-cookie-consent-banner]').forEach(function (banner) {
+      if (banner.dataset.cookieConsentInitialized === 'true') {
+        return;
+      }
+
+      banner.dataset.cookieConsentInitialized = 'true';
+      var preference = banner.querySelector('[data-cookie-consent-preference="analytics"]');
+      var preferencesForm = banner.querySelector('[data-cookie-consent-form="preferences"]');
+      var analyticsInput = banner.querySelector('[data-cookie-consent-analytics-input]');
+
+      if (preference && preferencesForm && analyticsInput) {
+        preferencesForm.addEventListener('submit', function () {
+          analyticsInput.value = preference.checked ? 'true' : 'false';
+        });
+      }
+
+      banner.querySelectorAll('form').forEach(function (form) {
+        form.addEventListener('submit', function () {
+          var input = form.querySelector('[name="analytics_consent"]');
+          if (input && input.value === 'false') {
+            revokeMatomoConsent();
+          }
+        });
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', initCookieConsentBanners);
+  document.addEventListener('turbo:load', initCookieConsentBanners);
+})();

--- a/app/assets/stylesheets/cookie_consent.scss
+++ b/app/assets/stylesheets/cookie_consent.scss
@@ -1,0 +1,69 @@
+.cookie-consent-banner {
+  background: var(--primary-color, #1f2933);
+  bottom: 1rem;
+  box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.2);
+  color: #fff;
+  left: 1rem;
+  max-width: 42rem;
+  padding: 1rem;
+  position: fixed;
+  right: 1rem;
+  z-index: 1050;
+}
+
+.cookie-consent-banner a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.cookie-consent-banner__title {
+  color: inherit;
+  font-size: 1.25rem;
+  margin: 0 0 0.5rem;
+}
+
+.cookie-consent-banner__description p,
+.cookie-consent-banner__category p {
+  margin-bottom: 0.5rem;
+}
+
+.cookie-consent-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.cookie-consent-banner__form {
+  margin: 0;
+}
+
+.cookie-consent-banner__category {
+  margin-bottom: 0.75rem;
+}
+
+.cookie-consent-banner__category h3 {
+  color: inherit;
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.cookie-consent-banner__checkbox {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.cookie-consent-banner__checkbox label {
+  font-weight: 700;
+  margin-bottom: 0;
+}
+
+.cookie-consent-banner__required {
+  font-weight: 700;
+}
+
+.cookie-consent-page {
+  padding-bottom: 12rem;
+  padding-top: 2rem;
+}

--- a/app/controllers/cookie_consent_controller.rb
+++ b/app/controllers/cookie_consent_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class CookieConsentController < ApplicationController
+  include AnalyticsHelper
+
+  layout :determine_layout
+
+  def show
+    redirect_to root_path unless extended_cookie_consent_enabled?
+  end
+
+  def update
+    analytics_allowed = analytics_consent_param
+    return invalid_consent_request unless analytics_allowed == true || analytics_allowed == false
+
+    remember_cookie_consent(analytics_allowed)
+
+    if request.format.json?
+      render json: { cookies_accepted: true, analytics_consent: analytics_allowed }
+    else
+      redirect_back fallback_location: root_path, status: :see_other
+    end
+  end
+
+  private
+
+  def analytics_consent_param
+    value = if params.key?(:analytics_consent)
+              params[:analytics_consent]
+            elsif params.key?(:analytics_preference)
+              params[:analytics_preference]
+            end
+
+    return value if value == true || value == false
+    return true if value == 'true'
+    return false if value == 'false'
+
+    nil
+  end
+
+  def invalid_consent_request
+    if request.format.json?
+      render json: { error: 'analytics_consent must be true or false' }, status: :unprocessable_entity
+    else
+      render plain: 'analytics_consent must be true or false', status: :unprocessable_entity
+    end
+  end
+
+  def remember_cookie_consent(analytics_allowed)
+    write_consent_cookie('cookies_accepted', 'true')
+    write_consent_cookie(analytics_consent_cookie_name, analytics_allowed ? 'true' : 'false')
+  end
+
+  def write_consent_cookie(name, value)
+    options = {
+      value: value,
+      expires: AnalyticsHelper::CONSENT_COOKIE_EXPIRY.from_now,
+      path: '/',
+      httponly: false,
+      same_site: :lax,
+      secure: request.ssl?
+    }
+    options[:domain] = analytics_consent_cookie_domain if analytics_consent_cookie_domain
+    cookies[name] = options
+  end
+end

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module AnalyticsHelper
+  DEFAULT_CONSENT_COOKIE_NAME = 'analytics_consent'.freeze
+  CONSENT_COOKIE_EXPIRY = 6.months
+  def analytics_provider
+    resolved_analytics_provider
+  end
+
+  def resolved_analytics_provider
+    explicit = configured_analytics_provider
+    return explicit_provider(explicit) unless explicit.nil?
+
+    return 'google' if google_analytics_tag_id.present?
+    return 'matomo' if matomo_configured?
+
+    nil
+  end
+
+  def analytics_enabled?
+    case resolved_analytics_provider
+    when 'google'
+      google_analytics_tag_id.present?
+    when 'matomo'
+      matomo_configured?
+    else
+      false
+    end
+  end
+
+  def analytics_tracking_enabled?
+    analytics_enabled? && analytics_consented?
+  end
+
+  def analytics_consent_required?
+    return false unless analytics_enabled?
+
+    strict_boolean(analytics_configuration_value('ANALYTICS_REQUIRE_CONSENT',
+                                                  (defined?($ANALYTICS_REQUIRE_CONSENT) ? $ANALYTICS_REQUIRE_CONSENT : nil),
+                                                  :require_consent),
+                   default: true)
+  end
+
+  def extended_cookie_consent_enabled?
+    analytics_enabled? && analytics_consent_required?
+  end
+
+  def analytics_consented?
+    return true unless analytics_consent_required?
+
+    cookies[analytics_consent_cookie_name].to_s == 'true'
+  end
+
+  def show_cookie_consent_banner?
+    extended_cookie_consent_enabled? && cookies[analytics_consent_cookie_name].nil?
+  end
+
+  def analytics_consent_cookie_name
+    name = analytics_configuration_value('ANALYTICS_CONSENT_COOKIE_NAME',
+                                         (defined?($ANALYTICS_CONSENT_COOKIE_NAME) ? $ANALYTICS_CONSENT_COOKIE_NAME : nil),
+                                         :consent_cookie_name).to_s.strip
+    name.match?(/\A[A-Za-z0-9_-]+\z/) ? name : DEFAULT_CONSENT_COOKIE_NAME
+  end
+
+  def analytics_consent_cookie_domain
+    domain = analytics_configuration_value('ANALYTICS_CONSENT_COOKIE_DOMAIN',
+                                            (defined?($ANALYTICS_CONSENT_COOKIE_DOMAIN) ? $ANALYTICS_CONSENT_COOKIE_DOMAIN : nil),
+                                            :consent_cookie_domain).to_s.strip
+    return nil if domain.blank?
+    return nil unless domain.length <= 253 && domain.match?(/\A\.?[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?\z/)
+    return nil if domain.include?('..')
+
+    domain
+  end
+
+  def google_analytics_tag_id
+    credentials_id = Rails.application.credentials.dig(:google_analytics, :tag_id)
+    value = [credentials_id,
+             ENV['ANALYTICS_ID'],
+             (defined?($ANALYTICS_ID) ? $ANALYTICS_ID : nil),
+             analytics_settings_value(:google, :tag_id)].find { |item| configured_value?(item) }
+    value.to_s.strip.presence
+  rescue StandardError
+    nil
+  end
+
+  def matomo_configured?
+    matomo_tracking_base_url.present? && matomo_site_id.present?
+  end
+
+  def matomo_tracking_base_url
+    normalize_matomo_url(analytics_configuration_value('MATOMO_URL',
+                                                        (defined?($MATOMO_URL) ? $MATOMO_URL : nil),
+                                                        :matomo, :url))
+  end
+
+  def matomo_site_id
+    value = analytics_configuration_value('MATOMO_SITE_ID',
+                                          (defined?($MATOMO_SITE_ID) ? $MATOMO_SITE_ID : nil),
+                                          :matomo, :site_id).to_s.strip
+    value.match?(/\A[1-9]\d*\z/) ? value : nil
+  end
+
+  private
+
+  def configured_analytics_provider
+    value = analytics_configuration_value('ANALYTICS_PROVIDER',
+                                          (defined?($ANALYTICS_PROVIDER) ? $ANALYTICS_PROVIDER : nil),
+                                          :provider)
+    return nil unless configured_value?(value)
+
+    value.to_s.strip.downcase
+  end
+
+  def explicit_provider(provider)
+    case provider
+    when 'google'
+      google_analytics_tag_id.present? ? 'google' : nil
+    when 'matomo'
+      matomo_configured? ? 'matomo' : nil
+    when 'none'
+      nil
+    else
+      nil
+    end
+  end
+
+  def analytics_configuration_value(environment_name, global_value, *settings_path)
+    values = [ENV[environment_name], global_value, analytics_settings_value(*settings_path)]
+    values.find { |value| configured_value?(value) }
+  end
+
+  def configured_value?(value)
+    !value.nil? && !(value.is_a?(String) && value.strip.empty?)
+  end
+
+  def strict_boolean(value, default:)
+    return value if value == true || value == false
+    return default unless configured_value?(value)
+
+    case value.to_s.strip.downcase
+    when 'true' then true
+    when 'false' then false
+    else default
+    end
+  end
+
+  def normalize_matomo_url(value)
+    return nil unless configured_value?(value)
+
+    uri = URI.parse(value.to_s.strip)
+    return nil unless %w[http https].include?(uri.scheme) && uri.host.present?
+
+    uri.query = nil
+    uri.fragment = nil
+    uri.path = uri.path.to_s.sub(%r{/+\z}, '')
+    uri.to_s.sub(%r{/+\z}, '')
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def analytics_settings_value(*path)
+    return nil unless Rails.configuration.respond_to?(:settings)
+
+    value = config_value(Rails.configuration.settings, :analytics)
+    path.each do |key|
+      value = config_value(value, key)
+      return nil if value.nil?
+    end
+    value
+  rescue StandardError
+    nil
+  end
+
+  def config_value(value, key)
+    return nil if value.nil?
+    return value[key] if value.respond_to?(:key?) && value.key?(key)
+    return value[key.to_s] if value.respond_to?(:key?) && value.key?(key.to_s)
+    return value.public_send(key) if value.respond_to?(key)
+
+    nil
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
   REST_URI = $REST_URL
   API_KEY = $API_KEY
 
-  include ModalHelper, MultiLanguagesHelper, UrlsHelper, ComponentsHelper
+  include AnalyticsHelper, ModalHelper, MultiLanguagesHelper, UrlsHelper, ComponentsHelper
 
 
   RESOLVE_NAMESPACE = {:omv => "http://omv.ontoware.org/2005/05/ontology#", :skos => "http://www.w3.org/2004/02/skos/core#", :owl => "http://www.w3.org/2002/07/owl#",

--- a/app/views/application/_cookie_consent_banner.html.haml
+++ b/app/views/application/_cookie_consent_banner.html.haml
@@ -1,0 +1,30 @@
+.cookie-consent-banner{role: 'dialog', 'aria-labelledby' => 'cookie-consent-title', 'aria-describedby' => 'cookie-consent-description', data: { cookie_consent_banner: true }}
+  .cookie-consent-banner__content
+    %h2#cookie-consent-title.cookie-consent-banner__title= t('cookies_modal.extended_title')
+    #cookie-consent-description.cookie-consent-banner__description
+      %p= t('cookies_modal.extended_paragraph1', portal: portal_name)
+      %p= t('cookies_modal.extended_paragraph2')
+      %p.cookie-consent-banner__privacy-link
+        = link_to t('cookies_modal.privacy_link'), "#{$FOOTER_LINKS.dig(:sections, :agreements, :privacy_policy)}#{t('cookies_modal.privacy_policy_anchor')}"
+
+    .cookie-consent-banner__category
+      %h3= t('cookies_modal.essential_title')
+      %p= t('cookies_modal.essential_description')
+      %p.cookie-consent-banner__required= t('cookies_modal.required_label')
+
+    .cookie-consent-banner__category
+      .cookie-consent-banner__checkbox
+        %input#analytics-preference{type: 'checkbox', checked: cookies[analytics_consent_cookie_name].to_s == 'true', data: { cookie_consent_preference: 'analytics' }}
+        %label{for: 'analytics-preference'}= t('cookies_modal.analytics_title')
+      %p= t('cookies_modal.analytics_description')
+
+    .cookie-consent-banner__actions
+      = form_with url: cookie_consent_path, method: :post, local: true, html: { class: 'cookie-consent-banner__form', data: { cookie_consent_form: 'accept' } } do
+        = hidden_field_tag :analytics_consent, 'true', id: 'analytics-consent-accept'
+        %button.btn.btn-primary{type: 'submit', data: { cookie_consent_submit: 'accept' }}= t('cookies_modal.accept_analytics_button')
+      = form_with url: cookie_consent_path, method: :post, local: true, html: { class: 'cookie-consent-banner__form', data: { cookie_consent_form: 'reject' } } do
+        = hidden_field_tag :analytics_consent, 'false', id: 'analytics-consent-reject'
+        %button.btn.btn-secondary{type: 'submit', data: { cookie_consent_submit: 'reject' }}= t('cookies_modal.reject_optional_button')
+      = form_with url: cookie_consent_path, method: :post, local: true, html: { class: 'cookie-consent-banner__form cookie-consent-banner__preferences-form', data: { cookie_consent_form: 'preferences' } } do
+        = hidden_field_tag :analytics_consent, cookies[analytics_consent_cookie_name].to_s == 'true' ? 'true' : 'false', id: 'analytics-consent-preferences', data: { cookie_consent_analytics_input: true }
+        %button.btn.btn-link.cookie-consent-banner__toggle{type: 'submit', data: { cookie_consent_submit: 'preferences' }}= t('cookies_modal.save_preferences_button')

--- a/app/views/application/_ga_tracking.html.haml
+++ b/app/views/application/_ga_tracking.html.haml
@@ -1,10 +1,40 @@
--# Google tag
-- tag_id = Rails.application.credentials.dig(:google_analytics, :tag_id) || $ANALYTICS_ID
-- if tag_id.present?
-  <script async src="https://www.googletagmanager.com/gtag/js?id=#{tag_id}"></script>
-  %script
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', '#{tag_id}');
+- if analytics_tracking_enabled?
+  - case resolved_analytics_provider
+  - when 'google'
+    - tag_id = google_analytics_tag_id
+    - if tag_id.present?
+      %script{async: true, src: "https://www.googletagmanager.com/gtag/js?id=#{ERB::Util.url_encode(tag_id)}"}
+      %script
+        :plain
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', #{tag_id.to_json.html_safe});
+  - when 'matomo'
+    - matomo_base = matomo_tracking_base_url
+    - site_id = matomo_site_id
+    - if matomo_base.present? && site_id.present?
+      %script
+        :plain
+          var _paq = window._paq = window._paq || [];
+      - if analytics_consent_required?
+        %script
+          :plain
+            _paq.push(['requireCookieConsent']);
+            _paq.push(['rememberCookieConsentGiven']);
+      %script
+        :plain
+          _paq.push(['trackPageView']);
+          _paq.push(['enableLinkTracking']);
+          (function() {
+            var u = #{matomo_base.to_json.html_safe} + '/';
+            _paq.push(['setTrackerUrl', u + 'matomo.php']);
+            _paq.push(['setSiteId', #{site_id.to_json.html_safe}]);
+            var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+            g.async = true;
+            g.src = u + 'matomo.js';
+            s.parentNode.insertBefore(g, s);
+          })();
+      %noscript
+        %p
+          %img{src: "#{ERB::Util.html_escape(matomo_base)}/matomo.php?idsite=#{ERB::Util.url_encode(site_id)}&rec=1", style: 'border:0;', alt: ''}

--- a/app/views/cookie_consent/show.html.haml
+++ b/app/views/cookie_consent/show.html.haml
@@ -1,0 +1,3 @@
+.container.cookie-consent-page
+  %h1= t('cookies_modal.title')
+  = render partial: 'application/cookie_consent_banner'

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -25,7 +25,9 @@
               - anchor = I18n.t("layout.footer.#{section}_anchor", default: "")
               %a{:href => "#{link}#{anchor}", :target => "_blank"}
                 = t("layout.footer."+section.to_s)
-          
+    - if extended_cookie_consent_enabled?
+      %p.cookie-preferences-link
+        = link_to t('cookies_modal.manage_preferences_link'), cookie_consent_path
 
 
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -25,9 +25,11 @@
   <!-- CSS -->
   <%= stylesheet_link_tag "https://use.fontawesome.com/releases/v5.2.0/css/all.css", integrity: "sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ", crossorigin: "anonymous" %>
   <%= stylesheet_link_tag "application" %>
+  <%= stylesheet_link_tag "cookie_consent" if extended_cookie_consent_enabled? %>
 
   <!-- JavaScript -->
   <%= javascript_include_tag "vendor" %>
+  <%= javascript_include_tag "cookie_consent", defer: true if extended_cookie_consent_enabled? %>
 
   <script>
       jQuery(document).data({
@@ -53,7 +55,11 @@
 </head>
 <body class="<%= controller_name %> <%= action_name %>">
 <%= render partial: 'layouts/topnav' %>
-<%= turbo_frame_tag :cookies_modal, src: cookies_path if cookies[:cookies_accepted].nil? && !(Rails.env.development? || Rails.env.test?) %>
+<% if extended_cookie_consent_enabled? %>
+  <%= render partial: 'application/cookie_consent_banner' if show_cookie_consent_banner? && controller_name != 'cookie_consent' %>
+<% else %>
+  <%= turbo_frame_tag :cookies_modal, src: cookies_path if cookies[:cookies_accepted].nil? && !(Rails.env.development? || Rails.env.test?) %>
+<% end %>
 
 <div class="flex-grow-1">
 <%= render partial: 'layouts/notices' %>

--- a/app/views/layouts/appliance.html.haml
+++ b/app/views/layouts/appliance.html.haml
@@ -14,8 +14,10 @@
     = stylesheet_link_tag "//fonts.googleapis.com/css?family=Droid+Sans:400", media: "all"
     = stylesheet_link_tag "https://use.fontawesome.com/releases/v5.2.0/css/all.css", integrity: "sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ", crossorigin: "anonymous"
     = stylesheet_link_tag "application", media: "all"
+    = stylesheet_link_tag "cookie_consent", media: "all" if extended_cookie_consent_enabled?
 
     = javascript_include_tag "vendor"
+    = javascript_include_tag "cookie_consent", defer: true if extended_cookie_consent_enabled?
 
     %script
       jQuery(document).data({bp: {config: #{bp_config_json.html_safe}, user: #{(session[:user] || {}).to_hash.to_json.html_safe}}});
@@ -25,7 +27,10 @@
 
   %body{:class => "#{controller_name} #{action_name}"}
     = render partial: "layouts/topnav"
-    = turbo_frame_tag :cookies_modal, src: cookies_path if cookies[:cookies_accepted].nil?
+    - if extended_cookie_consent_enabled?
+      = render partial: "application/cookie_consent_banner" if show_cookie_consent_banner? && controller_name != 'cookie_consent'
+    - else
+      = turbo_frame_tag :cookies_modal, src: cookies_path if cookies[:cookies_accepted].nil?
 
     %div.flex-grow-1
       = render partial: "layouts/notices"

--- a/config/bioportal_config_env.rb.sample
+++ b/config/bioportal_config_env.rb.sample
@@ -111,8 +111,23 @@ $RELEASE_VERSION = ENV['RELEASE_VERSION']
 # Enable Slices, filtering of ontologies based on subdomain and ontology groups
 $ENABLE_SLICES = false
 
+# Optional browser analytics. Set ANALYTICS_PROVIDER to google, matomo, or none.
+# When unset, existing Google configuration wins; Matomo is inferred only when
+# both MATOMO_URL and MATOMO_SITE_ID are configured.
+$ANALYTICS_PROVIDER = ENV['ANALYTICS_PROVIDER']
+
 # Google Analytics ID (optional)
 $ANALYTICS_ID = ENV['ANALYTICS_ID']
+
+# Matomo URL and site ID (optional)
+$MATOMO_URL = ENV['MATOMO_URL']
+$MATOMO_SITE_ID = ENV['MATOMO_SITE_ID']
+
+# Set true to require explicit analytics consent (default: false for compatibility).
+# For portal/slice sharing, use ANALYTICS_CONSENT_COOKIE_DOMAIN=.stage.matportal.org.
+$ANALYTICS_REQUIRE_CONSENT = ENV['ANALYTICS_REQUIRE_CONSENT']
+$ANALYTICS_CONSENT_COOKIE_NAME = ENV['ANALYTICS_CONSENT_COOKIE_NAME']
+$ANALYTICS_CONSENT_COOKIE_DOMAIN = ENV['ANALYTICS_CONSENT_COOKIE_DOMAIN']
 
 # Enable client request caching
 $CLIENT_REQUEST_CACHING = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -487,6 +487,18 @@ en:
     visualization: Visualization
   cookies_modal:
     accept_button: Accept
+    accept_analytics_button: Accept analytics cookies
+    analytics_description: Optional analytics cookies help us understand aggregate usage and improve the service. Analytics tracking is not loaded unless you accept this category.
+    analytics_title: Analytics cookies
+    essential_description: Required for login, security, language, and other core site features. These cookies cannot be switched off in this banner.
+    essential_title: Essential cookies
+    extended_paragraph1: '%{portal} uses essential cookies to provide core site features.'
+    extended_paragraph2: Optional analytics cookies are used only after you actively consent to analytics tracking.
+    extended_title: Cookie preferences
+    manage_preferences_link: Manage cookie preferences
+    reject_optional_button: Reject optional cookies
+    required_label: Always active
+    save_preferences_button: Save preferences
     paragraph1: '%{portal} uses cookies to help you navigate efficiently and for audience
       measurement. You will find detailed information about all cookies in the "Privacy
       policy" link'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   match 'cookies', to: 'home#set_cookies', via: [:post, :get]
+  get 'cookie_consent', to: 'cookie_consent#show'
+  post 'cookie_consent', to: 'cookie_consent#update'
 
   root to: 'home#index'
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,14 @@
 shared:
+  analytics:
+    provider: null
+    require_consent: false
+    consent_cookie_name: analytics_consent
+    consent_cookie_domain: null
+    matomo:
+      url: null
+      site_id: null
+    google:
+      tag_id: null
   links:
     about: 'https://www.bioontology.org/about-us/'
     cite: 'https://www.bioontology.org/about-us/#cite-bioportal'

--- a/test/controllers/cookie_consent_controller_test.rb
+++ b/test/controllers/cookie_consent_controller_test.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CookieConsentControllerTest < ActionDispatch::IntegrationTest
+  CONFIG_ENV = %w[
+    ANALYTICS_PROVIDER
+    ANALYTICS_REQUIRE_CONSENT
+    ANALYTICS_CONSENT_COOKIE_NAME
+    ANALYTICS_CONSENT_COOKIE_DOMAIN
+    ANALYTICS_ID
+    MATOMO_URL
+    MATOMO_SITE_ID
+  ].freeze
+
+  setup do
+    @original_env = CONFIG_ENV.to_h { |key| [key, ENV[key]] }
+    @original_settings = Rails.configuration.settings[:analytics].deep_dup
+    @original_footer_links = $FOOTER_LINKS
+    clear_configuration
+    $FOOTER_LINKS = Marshal.load(Marshal.dump(@original_footer_links))
+    $FOOTER_LINKS[:sections][:agreements][:privacy_policy] = 'https://privacy.example/portal'
+  end
+
+  teardown do
+    CONFIG_ENV.each { |key| ENV[key] = @original_env[key] }
+    Rails.configuration.settings[:analytics] = @original_settings
+    $FOOTER_LINKS = @original_footer_links
+  end
+
+  test 'valid JSON acceptance writes both consent cookies' do
+    configure_matomo
+
+    post cookie_consent_path,
+         params: { analytics_consent: 'true' },
+         headers: { 'ACCEPT' => 'application/json' }
+
+    assert_response :success
+    assert_equal({ 'cookies_accepted' => true, 'analytics_consent' => true }, JSON.parse(response.body))
+    assert_includes response.headers['Set-Cookie'], 'cookies_accepted=true'
+    assert_includes response.headers['Set-Cookie'], 'analytics_consent=true'
+  end
+
+  test 'valid JSON rejection stores false consent' do
+    configure_matomo
+
+    post cookie_consent_path,
+         params: { analytics_consent: 'false' },
+         headers: { 'ACCEPT' => 'application/json' }
+
+    assert_response :success
+    assert_equal false, JSON.parse(response.body)['analytics_consent']
+    assert_includes response.headers['Set-Cookie'], 'analytics_consent=false'
+  end
+
+  test 'canonical reject wins over preference fallback' do
+    configure_matomo
+
+    post cookie_consent_path,
+         params: { analytics_consent: 'false', analytics_preference: 'true' },
+         headers: { 'ACCEPT' => 'application/json' }
+
+    assert_response :success
+    assert_equal false, JSON.parse(response.body)['analytics_consent']
+  end
+
+  test 'missing, malformed, numeric, and array values are rejected without consent cookies' do
+    configure_matomo
+
+    [
+      {},
+      { analytics_consent: 'maybe' },
+      { analytics_consent: 1 },
+      { analytics_consent: ['true', 'false'] }
+    ].each do |params|
+      post cookie_consent_path, params: params, headers: { 'ACCEPT' => 'application/json' }
+      assert_response :unprocessable_entity
+      assert_equal 422, response.status
+      assert_no_match(/cookies_accepted|analytics_consent/, response.headers['Set-Cookie'].to_s)
+    end
+  end
+
+  test 'configured domain is applied to both new consent cookies' do
+    configure_matomo
+    ENV['ANALYTICS_CONSENT_COOKIE_DOMAIN'] = '.stage.matportal.org'
+
+    post cookie_consent_path,
+         params: { analytics_consent: 'true' },
+         headers: { 'ACCEPT' => 'application/json' }
+
+    assert_response :success
+    set_cookie = response.headers['Set-Cookie']
+    assert_equal 2, set_cookie.scan(/domain=\.stage\.matportal\.org/i).length
+  end
+
+  test 'manage page uses the portal privacy URL and shows controls' do
+    configure_matomo
+
+    get cookie_consent_path
+
+    assert_response :success
+    assert_select 'a[href="https://privacy.example/portal#h-privacy-policy"]'
+    assert_select 'form[action="/cookie_consent"]', minimum: 3
+    assert_select 'input[name="analytics_consent"]', minimum: 3
+    assert_select 'input#analytics-preference'
+  end
+
+  test 'accepted Google tracking remains Google-only' do
+    ENV['ANALYTICS_ID'] = 'G-EXISTING'
+    ENV['ANALYTICS_REQUIRE_CONSENT'] = 'true'
+    cookies['analytics_consent'] = 'true'
+
+    get cookie_consent_path
+
+    assert_response :success
+    assert_includes response.body, 'googletagmanager.com/gtag/js?id=G-EXISTING'
+    assert_includes response.body, "gtag('config', \"G-EXISTING\")"
+    assert_no_match(/matomo\.(?:js|php)/, response.body)
+  end
+
+  test 'Matomo markup is absent before consent and present after acceptance' do
+    configure_matomo
+
+    get cookie_consent_path
+    assert_response :success
+    assert_no_match(/matomo\.(?:js|php)/, response.body)
+
+    cookies['analytics_consent'] = 'true'
+    get cookie_consent_path
+    assert_response :success
+    assert_includes response.body, 'analytics.example.org/matomo'
+    assert_includes response.body, "g.src = u + 'matomo.js'"
+    assert_includes response.body, 'analytics.example.org/matomo/matomo.php'
+  end
+
+  test 'rejected consent renders no Matomo request markup and keeps manage link' do
+    configure_matomo
+    cookies['analytics_consent'] = 'false'
+
+    get cookie_consent_path
+
+    assert_response :success
+    assert_no_match(/matomo\.(?:js|php)/, response.body)
+    assert_select 'script[src*="cookie_consent"]'
+    assert_select 'a[href="/cookie_consent"]', text: 'Manage cookie preferences'
+  end
+
+  test 'legacy cookies endpoint remains available when extended consent is off' do
+    get cookies_path
+
+    assert_response :success
+    assert_includes response.body, 'Manage Cookie Consent'
+    assert_includes response.body, 'Privacy policy'
+  end
+
+  private
+
+  def configure_matomo
+    ENV['MATOMO_URL'] = 'https://analytics.example.org/matomo/'
+    ENV['MATOMO_SITE_ID'] = '42'
+    ENV['ANALYTICS_REQUIRE_CONSENT'] = 'true'
+  end
+
+  def clear_configuration
+    CONFIG_ENV.each { |key| ENV.delete(key) }
+    $ANALYTICS_PROVIDER = nil
+    $ANALYTICS_ID = nil
+    $MATOMO_URL = nil
+    $MATOMO_SITE_ID = nil
+    $ANALYTICS_REQUIRE_CONSENT = nil
+    $ANALYTICS_CONSENT_COOKIE_NAME = nil
+    $ANALYTICS_CONSENT_COOKIE_DOMAIN = nil
+  end
+end

--- a/test/helpers/analytics_helper_test.rb
+++ b/test/helpers/analytics_helper_test.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AnalyticsHelperTest < ActionView::TestCase
+  include AnalyticsHelper
+
+  CONFIG_ENV = %w[
+    ANALYTICS_PROVIDER
+    ANALYTICS_REQUIRE_CONSENT
+    ANALYTICS_CONSENT_COOKIE_NAME
+    ANALYTICS_CONSENT_COOKIE_DOMAIN
+    ANALYTICS_ID
+    MATOMO_URL
+    MATOMO_SITE_ID
+  ].freeze
+
+  setup do
+    @original_env = CONFIG_ENV.to_h { |key| [key, ENV[key]] }
+    @original_settings = Rails.configuration.settings[:analytics].deep_dup
+    @original_globals = {
+      provider: $ANALYTICS_PROVIDER,
+      id: $ANALYTICS_ID,
+      matomo_url: $MATOMO_URL,
+      matomo_site_id: $MATOMO_SITE_ID,
+      require_consent: $ANALYTICS_REQUIRE_CONSENT,
+      cookie_name: $ANALYTICS_CONSENT_COOKIE_NAME,
+      cookie_domain: $ANALYTICS_CONSENT_COOKIE_DOMAIN
+    }
+    clear_configuration
+    @cookies = {}
+  end
+
+  teardown do
+    CONFIG_ENV.each { |key| ENV[key] = @original_env[key] }
+    Rails.configuration.settings[:analytics] = @original_settings
+    $ANALYTICS_PROVIDER = @original_globals[:provider]
+    $ANALYTICS_ID = @original_globals[:id]
+    $MATOMO_URL = @original_globals[:matomo_url]
+    $MATOMO_SITE_ID = @original_globals[:matomo_site_id]
+    $ANALYTICS_REQUIRE_CONSENT = @original_globals[:require_consent]
+    $ANALYTICS_CONSENT_COOKIE_NAME = @original_globals[:cookie_name]
+    $ANALYTICS_CONSENT_COOKIE_DOMAIN = @original_globals[:cookie_domain]
+  end
+
+  test 'no provider configuration disables analytics' do
+    assert_nil resolved_analytics_provider
+    assert_not analytics_enabled?
+  end
+
+  test 'existing Google configuration remains the default provider' do
+    ENV['ANALYTICS_ID'] = 'G-EXISTING'
+
+    assert_equal 'google', resolved_analytics_provider
+    assert_equal 'G-EXISTING', google_analytics_tag_id
+    assert analytics_tracking_enabled?
+  end
+
+  test 'Matomo is inferred only when Google is not configured' do
+    ENV['MATOMO_URL'] = ' https://analytics.example.org/matomo/?ignored=1#fragment/ '
+    ENV['MATOMO_SITE_ID'] = '42'
+
+    assert_equal 'matomo', resolved_analytics_provider
+    assert_equal 'https://analytics.example.org/matomo', matomo_tracking_base_url
+    assert_equal '42', matomo_site_id
+  end
+
+  test 'explicit providers select only the requested configured provider' do
+    ENV['ANALYTICS_ID'] = 'G-EXISTING'
+    ENV['MATOMO_URL'] = 'https://analytics.example.org/matomo'
+    ENV['MATOMO_SITE_ID'] = '42'
+
+    ENV['ANALYTICS_PROVIDER'] = 'matomo'
+    assert_equal 'matomo', resolved_analytics_provider
+
+    ENV['ANALYTICS_PROVIDER'] = 'google'
+    assert_equal 'google', resolved_analytics_provider
+  end
+
+  test 'none and invalid explicit providers fail closed without fallback' do
+    ENV['MATOMO_URL'] = 'https://analytics.example.org/matomo'
+    ENV['MATOMO_SITE_ID'] = '42'
+
+    ENV['ANALYTICS_PROVIDER'] = 'none'
+    assert_nil resolved_analytics_provider
+    assert_not analytics_enabled?
+
+    ENV['ANALYTICS_PROVIDER'] = 'invalid'
+    assert_nil resolved_analytics_provider
+    assert_not analytics_enabled?
+    assert_not extended_cookie_consent_enabled?
+  end
+
+  test 'Matomo requires an HTTP(S) URL with a host and a positive site id' do
+    ENV['MATOMO_URL'] = 'javascript:alert(1)'
+    ENV['MATOMO_SITE_ID'] = '42'
+    assert_nil matomo_tracking_base_url
+    assert_not analytics_enabled?
+
+    ENV['MATOMO_URL'] = 'https://analytics.example.org/matomo'
+    ENV['MATOMO_SITE_ID'] = 'missing'
+    assert_nil matomo_site_id
+    assert_not analytics_enabled?
+  end
+
+  test 'false environment consent setting overrides true settings' do
+    ENV['MATOMO_URL'] = 'https://analytics.example.org/matomo'
+    ENV['MATOMO_SITE_ID'] = '42'
+    Rails.configuration.settings[:analytics][:require_consent] = true
+    ENV['ANALYTICS_REQUIRE_CONSENT'] = 'false'
+
+    assert_not analytics_consent_required?
+  end
+
+  test 'required consent gates tracking on the exact accepted cookie value' do
+    ENV['MATOMO_URL'] = 'https://analytics.example.org/matomo'
+    ENV['MATOMO_SITE_ID'] = '42'
+    ENV['ANALYTICS_REQUIRE_CONSENT'] = 'true'
+
+    assert_not analytics_tracking_enabled?
+    @cookies['analytics_consent'] = 'false'
+    assert_not analytics_tracking_enabled?
+    @cookies['analytics_consent'] = 'true'
+    assert analytics_tracking_enabled?
+  end
+
+  test 'consent cookie domain is configurable and host-only by default' do
+    assert_nil analytics_consent_cookie_domain
+
+    ENV['ANALYTICS_CONSENT_COOKIE_DOMAIN'] = '.stage.matportal.org'
+    assert_equal '.stage.matportal.org', analytics_consent_cookie_domain
+  end
+
+  private
+
+  def cookies
+    @cookies
+  end
+
+  def clear_configuration
+    CONFIG_ENV.each { |key| ENV.delete(key) }
+    $ANALYTICS_PROVIDER = nil
+    $ANALYTICS_ID = nil
+    $MATOMO_URL = nil
+    $MATOMO_SITE_ID = nil
+    $ANALYTICS_REQUIRE_CONSENT = nil
+    $ANALYTICS_CONSENT_COOKIE_NAME = nil
+    $ANALYTICS_CONSENT_COOKIE_DOMAIN = nil
+  end
+end


### PR DESCRIPTION
## Summary

- add optional Matomo tracking alongside the existing Google Analytics configuration
- support explicit `google`, `matomo`, and `none` provider selection
- add an optional consent banner with accept, reject, and manage-preferences flows
- support a configurable consent-cookie name and domain for portal slices
- preserve the existing cookie flow when analytics consent is not enabled

Tracking is omitted until consent is accepted when `ANALYTICS_REQUIRE_CONSENT=true`. Rejecting a previous choice queues Matomo consent and cookie cleanup.

## Testing

- Ruby and JavaScript syntax checks
- Haml parsing
- settings and locale YAML parsing
- focused helper and controller coverage for provider selection, consent validation, cookie scope, tracking markup, and the privacy-policy link
